### PR TITLE
Added one second wait before updating user in user-update IT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 *.log
 .env
 .vscode
+*.iml


### PR DESCRIPTION
It looks like Okta's lastUpdated minimum resolution is one second, so we need to ensure we wait at least that long, or this IT does not run consistently between machines
Updated the assert error message to output in the format of:
  `AssertionError: lastUpdated has not been increased: expected '2017-06-19T15:55:03.000Z' to be above 2017-06-19T15:55:03.000Z`