### PR TITLE
Only parse JSON responses if we need to

### DIFF
--- a/src/generated-client.js
+++ b/src/generated-client.js
@@ -440,7 +440,7 @@ class GeneratedApiClient {
 
     url += queryString ? ('?' + queryString) : '';
 
-    const request = this.http.post(url);
+    const request = this.http.postJson(url);
     return request.then(jsonRes => new models.UserActivationToken(jsonRes, this));
   }
 
@@ -469,7 +469,7 @@ class GeneratedApiClient {
 
     url += queryString ? ('?' + queryString) : '';
 
-    const request = this.http.post(url);
+    const request = this.http.postJson(url);
     return request.then(jsonRes => new models.TempPassword(jsonRes, this));
   }
 
@@ -499,7 +499,7 @@ class GeneratedApiClient {
 
     url += queryString ? ('?' + queryString) : '';
 
-    const request = this.http.post(url);
+    const request = this.http.postJson(url);
     return request.then(jsonRes => new models.ResetPasswordToken(jsonRes, this));
   }
 

--- a/templates/generated-client.js.hbs
+++ b/templates/generated-client.js.hbs
@@ -38,20 +38,40 @@ class GeneratedApiClient {
     {{/if}}
     {{#if (eq method 'post')}}
     {{#if bodyModel}}
+    {{#if responseModel}}
     const request = this.http.postJson(url, {
       body: {{camelCase bodyModel}}
     });
     {{else}}
+    const request = this.http.post(url, {
+      body: {{camelCase bodyModel}}
+    });
+    {{/if}}
+    {{else}}
+    {{#if responseModel}}
+    const request = this.http.postJson(url);
+    {{else}}
     const request = this.http.post(url);
+    {{/if}}
     {{/if}}
     {{/if}}
     {{#if (eq method 'put')}}
     {{#if bodyModel}}
+    {{#if responseModel}}
     const request = this.http.putJson(url, {
       body: {{camelCase bodyModel}}
     });
     {{else}}
+    const request = this.http.put(url, {
+      body: {{camelCase bodyModel}}
+    });
+    {{/if}}
+    {{else}}
+    {{#if responseModel}}
+    const request = this.http.putJson(url);
+    {{else}}
     const request = this.http.put(url);
+    {{/if}}
     {{/if}}
     {{/if}}
     {{#if responseModel}}


### PR DESCRIPTION
This modifies the template to be aware of the schema of the response.  If there is no schema for the response, we assume it should not be parsed as JSON.  Otherwise, assume it is a JSON response.