### PR TITLE
Updates YAML format to include 'okta' root

### DIFF
--- a/okta.yaml
+++ b/okta.yaml
@@ -1,0 +1,4 @@
+okta:
+  client:
+    orgUrl: null
+    token: null

--- a/src/config-loader.js
+++ b/src/config-loader.js
@@ -68,7 +68,7 @@ class ConfigLoader {
   }
 
   applyYamlFile(path) {
-    this.apply(yaml.safeLoad(fs.readFileSync(path)));
+    this.apply(yaml.safeLoad(fs.readFileSync(path)).okta);
   }
 
   apply(config) {

--- a/test/unit/config-loader.js
+++ b/test/unit/config-loader.js
@@ -36,8 +36,10 @@ describe('ConfigLoader', () => {
 
     it('should override defaults with ~/.okta/okta.yaml file', () => {
       fakeFs.file(path.join(os.homedir(), '.okta', 'okta.yaml'), yaml.safeDump({
-        client: {
-          orgUrl: 'foo'
+        okta: {
+          client: {
+            orgUrl: 'foo'
+          }
         }
       }));
       loader.applyDefaults();
@@ -51,8 +53,10 @@ describe('ConfigLoader', () => {
 
     it('should override ~/.okta/okta.yaml with okta.yaml in the process context', () => {
       fakeFs.file(path.join(process.cwd(), 'okta.yaml'), yaml.safeDump({
-        client: {
-          orgUrl: 'bar'
+        okta: {
+          client: {
+            orgUrl: 'bar'
+          }
         }
       }));
       loader.applyDefaults();


### PR DESCRIPTION
- 🌱  Includes default `okta.yaml` to ease onboarding
- :fire: Changes YAML parsing to include `okta` root.
- ✅  Updates config tests