### PR TITLE
Reverting junit reporter change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ jsdoc/
 
 .envrc
 .DS_Store
-test-results.xml

--- a/package-lock.json
+++ b/package-lock.json
@@ -805,12 +805,6 @@
         "supports-color": "2.0.0"
       }
     },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
-      "dev": true
-    },
     "ci-info": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
@@ -998,12 +992,6 @@
         "shebang-command": "1.2.0",
         "which": "1.3.1"
       }
-    },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
-      "dev": true
     },
     "cssom": {
       "version": "0.3.2",
@@ -4687,17 +4675,6 @@
       "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
       "dev": true
     },
-    "md5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
-      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
-      "dev": true,
-      "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "1.1.6"
-      }
-    },
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -4924,36 +4901,6 @@
           "dev": true,
           "requires": {
             "has-flag": "1.0.0"
-          }
-        }
-      }
-    },
-    "mocha-junit-reporter": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-1.17.0.tgz",
-      "integrity": "sha1-LlFJ7UD8XS48px5C21qx/snG2Fw=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "md5": "2.2.1",
-        "mkdirp": "0.5.1",
-        "strip-ansi": "4.0.0",
-        "xml": "1.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -8429,12 +8376,6 @@
         "async-limiter": "1.0.0",
         "safe-buffer": "5.1.2"
       }
-    },
-    "xml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
-      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "jest": "jest --coverage test/jest/*.js",
     "predocs": "rm -rf ./jsdocs && mkdir jsdocs/ && ./utils/make-jsdoc-readme.js > ./jsdocs/jsdoc-temp.md",
     "docs": "./node_modules/.bin/jsdoc src/ -c ./docs/config.json -d ./jsdocs/ -P ./package.json -R ./jsdocs/jsdoc-temp.md -r",
-    "test:integration": "nyc --reporter=text --reporter=html mocha test/it/*.js --no-timeouts --reporter mocha-junit-reporter",
+    "test:integration": "nyc --reporter=text --reporter=html mocha test/it/*.js --no-timeouts",
     "test:unit": "nyc --reporter=text --reporter=html mocha test/unit/*.js --no-timeouts",
     "test": "npm run eslint && npm run test:unit && npm run test:integration && npm run jest"
   },
@@ -44,7 +44,6 @@
     "jest": "^23.1.0",
     "jsdoc": "^3.4.0",
     "mocha": "^3.4.1",
-    "mocha-junit-reporter": "^1.17.0",
     "nyc": "^10.3.2",
     "speakeasy": "^2.0.0"
   }


### PR DESCRIPTION
* Cron job is failing after adding junit reporter - https://travis-ci.org/okta/okta-sdk-nodejs/builds/407885467
* Test results are not shown on command line as well 
* Passing cron job with this revert - https://travis-ci.org/okta/okta-sdk-nodejs/jobs/407889850
* Will figure out another way to report results on bacon. junit xml only helps provide test numbers on bacon UI (passed/failed) We could sacrifice this small benefit and instead go through the bacon logs to find out test results.