### PR TITLE
Fixes API validation failure in tests

### DIFF
--- a/test/it/client-update-application.js
+++ b/test/it/client-update-application.js
@@ -27,7 +27,7 @@ describe('client.updateApplication()', () => {
       await utils.removeAppByLabel(client, application.label);
       createdApplication = await client.createApplication(application);
 
-      const updatedLabel = faker.random.words();
+      const updatedLabel = faker.random.word();
       createdApplication.label = updatedLabel;
       await createdApplication.update();
       expect(createdApplication.label).to.equal(updatedLabel);

--- a/test/it/group-rule-operations.js
+++ b/test/it/group-rule-operations.js
@@ -41,7 +41,7 @@ describe('Group-Rule API tests', () => {
     // 2. Create a group rule and verify rule executes
     const rule = {
       type: 'group_rule',
-      name: faker.random.words(),
+      name: faker.random.word(),
       conditions: {
         people: {
           users: {
@@ -85,7 +85,7 @@ describe('Group-Rule API tests', () => {
     // 4. Deactivate the rule and update it
     await client.deactivateRule(createdRule.id);
 
-    createdRule.name = faker.random.words();
+    createdRule.name = faker.random.word();
     createdRule.conditions.expression.value = 'user.lastName==\"incorrect\"';
     const updatedRule = await createdRule.update();
     await updatedRule.activate();


### PR DESCRIPTION
* Using `faker.random.words()` in tests sometimes causes the following error - 
` Okta HTTP 400 E0000001 Api validation failed: name. name: The field is too long`

* Failed build - https://travis-ci.org/okta/okta-sdk-nodejs/jobs/416135114