### PR TITLE
Enable async iteration on any Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ orgUsersCollection.each(user => {
 .then(() => console.log('All users have been listed'));
 ```
 
+If you're using a version of Node 10 or greater, you can use async iterators.
+
+```javascript
+for await (let user of client.listUsers()) {
+    console.log(user);
+}
+```
+
 For more information about this API see [Users: Get User].
 
 #### Search for Users

--- a/src/collection.js
+++ b/src/collection.js
@@ -57,6 +57,12 @@ class Collection {
     });
   }
 
+  [Symbol.asyncIterator]() {
+    return {
+      next: () => this.next()
+    };
+  }
+
   getNextPage() {
     return this.client.http.http(this.nextUri, null, {isCollection: true})
     .then(res => {


### PR DESCRIPTION
The SDK's api already conforms to the async iteration spec. `Symbol.asyncIterator` must be present for Node to allow [async iteration](https://github.com/tc39/proposal-async-iteration).

Tested locally on Node 6+. Async iteration is only supported by default on Node 10+, so `Symbol.asyncIterator` is inert in versions without support.