### PR TITLE
Updated minimum version number in README to 6.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Node.js API Client for the [Okta Platform API].
 
-Requires Node.js version 4.8.3 or higher.
+Requires Node.js version 6.9.0 or higher.
 
 Need help? Contact [developers@okta.com](mailto:developers@okta.com) or use the [Okta Developer Forum].
 


### PR DESCRIPTION
Node.js Foundation has v4.x at "End of Life" as of April 30, 2018.

This PR is to address #81