### PR TITLE
DRAFT: Proposed error improvements

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -42,6 +42,12 @@ class Http {
 
         try {
           err = new OktaApiError(response.url, response.status, JSON.parse(body), response.headers);
+          if (err.errorCode === 'E0000011') {
+            // eslint-disable-next-line no-console
+            console.error(err);
+            process.exit(1);
+          }
+
         } catch (e) {
           err = new HttpError(response.url, response.status, body, response.headers);
         }

--- a/src/request-executor.js
+++ b/src/request-executor.js
@@ -19,6 +19,13 @@ class RequestExecutor extends EventEmitter {
     return isoFetch(request.url, request).then(response => {
       this.emit('response', response);
       return response;
+    })
+    .catch(e => {
+      if (e.code === 'ENOTFOUND') {
+        // eslint-disable-next-line no-console
+        console.error(e);
+        process.exit(1);
+      }
     });
   }
 }


### PR DESCRIPTION
There are two common configuration errors that developers run into:
- Invalid API token
- Invalid Org URL (DNS name not found)

In either situation, the underlying HTTP error bubbles up the promise chain.

If the developer has not implemented a catch, they get a generic error about an uncaught promise exception

This improves on that by printing the exceptions for the common cases above, then exiting the process with a non-zero code