### PR TITLE
feat: handle access token refresh - OKTA-291504

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Okta Node SDK Changelog
 
+## 3.3.1
+
+- [#138](https://github.com/okta/okta-sdk-nodejs/pull/138) Add strategy to handle access token refresh
+
 ## 3.2.0
 
 - [#128](https://github.com/okta/okta-sdk-nodejs/pull/128) Adds support for OAuth

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okta/okta-sdk-nodejs",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Okta API wrapper for Node.js",
   "engines": {
     "node": ">=8.11"

--- a/src/client.js
+++ b/src/client.js
@@ -44,7 +44,7 @@ class Client extends GeneratedApiClient {
       errors.push('Okta Org URL not provided');
     }
 
-    if (!parsedConfig.client.token) {
+    if (!parsedConfig.client.token && parsedConfig.client.authorizationMode !== 'PrivateKey') {
       errors.push('Okta API token not provided');
     }
 

--- a/src/http.js
+++ b/src/http.js
@@ -75,10 +75,10 @@ class Http {
       .catch(error => {
         // Handle oauth access token expiration
         if (this.oauth && error && error.status === 401) {
+          this.oauth.clearCachedAccessToken();
           return this.oauth.introspectAccessToken()
             .then(({ active }) => {
               if (active === false) {
-                this.oauth.clearCachedAccessToken();
                 return this.http(uri, request, context);
               }
               // Access token is still active or other error happen, re-throw

--- a/src/jwt.js
+++ b/src/jwt.js
@@ -32,12 +32,12 @@ function getPemAndJwk(privateKey) {
   }
 }
 
-function makeJwt(client) {
+function makeJwt(client, endpoint) {
   const now = Math.floor(new Date().getTime() / 1000); // seconds since epoch
   const plus5Minutes = new Date((now + (5 * 60)) * 1000); // Date object
 
   const claims = {
-    aud: `${client.baseUrl}/oauth2/v1/token`,
+    aud: `${client.baseUrl}${endpoint}`,
   };
   return getPemAndJwk(client.privateKey)
     .then(res => {

--- a/src/oauth.js
+++ b/src/oauth.js
@@ -57,34 +57,6 @@ class OAuth {
       });
   }
 
-  introspectAccessToken() {
-    if (!this.accessToken) {
-      return Promise.reject(new Error('No accessToken in cache to be introspected.'));
-    }
-
-    const endpoint = '/oauth2/v1/introspect';
-    return this.getJwt(endpoint)
-      .then(jwt => {
-        const params = formatParams({
-          token: this.accessToken,
-          token_type_hint: 'access_token',
-          client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
-          client_assertion: jwt
-        });
-        return this.client.requestExecutor.fetch({
-          url: `${this.client.baseUrl}${endpoint}`,
-          method: 'POST',
-          body: params,
-          headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/x-www-form-urlencoded'
-          }
-        });
-      })
-      .then(Http.errorFilter)
-      .then(res => res.json());
-  }
-
   clearCachedAccessToken() {
     this.accessToken = null;
   }

--- a/test/jest/http.test.js
+++ b/test/jest/http.test.js
@@ -39,6 +39,72 @@ describe('Http class', () => {
       expect(http.oauth).toBe(oauth);
     });
   });
+  describe('errorFilter', () => {
+    it('should resolve promise for status in 200 - 300 range', () => {
+      expect.assertions(1);
+      const jsonResponse = { data: 'fake data' };
+      const response = {
+        status: 200,
+        json: jest.fn().mockResolvedValueOnce(jsonResponse)
+      };
+      return Promise.resolve(response)
+        .then(Http.errorFilter)
+        .then(res => res.json())
+        .then(res => {
+          expect(res).toEqual(jsonResponse);
+        });
+    });
+    it('should reject with OktaApiError for json response with status equal or greater than 300', () => {
+      expect.assertions(2);
+      const errorObject = {
+        errorCode: 'a fake error'
+      };
+      const response = {
+        status: 401,
+        url: 'http://fakey.local',
+        headers: { fakeHeaders: true },
+        text: jest.fn().mockResolvedValueOnce(JSON.stringify(errorObject))
+      };
+      return Promise.resolve(response)
+        .then(Http.errorFilter)
+        .catch(err => {
+          expect(err).toBeInstanceOf(OktaApiError);
+          expect(err).toEqual({
+            name: 'OktaApiError',
+            status: 401,
+            errorCode: 'a fake error',
+            errorSummary: '',
+            errorCauses: undefined,
+            errorLink: undefined,
+            errorId: undefined,
+            url: 'http://fakey.local',
+            headers: { fakeHeaders: true },
+            message: 'Okta HTTP 401 a fake error '
+          });
+        });
+    });
+    it('should reject with HttpError for text response with status equal or greater than 300', () => {
+      expect.assertions(2);
+      const response = {
+        status: 500,
+        url: 'http://fakey.local',
+        headers: { fakeHeaders: true },
+        text: jest.fn().mockResolvedValueOnce('an unknown error in plain text')
+      };
+      return Promise.resolve(response)
+        .then(Http.errorFilter)
+        .catch(err => {
+          expect(err).toBeInstanceOf(HttpError);
+          expect(err).toEqual({
+            name: 'HttpError',
+            status: 500,
+            url: 'http://fakey.local',
+            headers: { fakeHeaders: true },
+            message: 'HTTP 500 an unknown error in plain text'
+          });
+        });
+    });
+  });
   describe('prepareRequest', () => {
     let request;
     beforeEach(() => {
@@ -47,6 +113,7 @@ describe('Http class', () => {
       };
     });
     it('does not modify request headers if there is no "oauth" object', () => {
+      expect.assertions(1);
       const http = new Http({});
       return http.prepareRequest(request)
         .then(() => {
@@ -54,82 +121,20 @@ describe('Http class', () => {
         });
     });
     describe('OAuth', () => {
-      let oauth;
-      let getAccessTokenResponse;
-      let accessToken;
-      beforeEach(() => {
-        accessToken = {
+      it('should set Authorization header', () => {
+        expect.assertions(2);
+        const accessToken = {
           access_token: 'abcd1234'
         };
-        getAccessTokenResponse = {
-          status: 200,
-          url: 'http://fakey.local',
-          headers: { fakeHeaders: true },
-          json: jest.fn().mockImplementation(() => Promise.resolve(accessToken))
+        const oauth = {
+          getAccessToken: jest.fn().mockResolvedValueOnce(accessToken)
         };
-        oauth = {
-          getAccessToken: jest.fn().mockImplementation(() => Promise.resolve(getAccessTokenResponse))
-        };
-      });
-      it('Sets authorization header if accessToken has been set', () => {
-        const http = new Http({ oauth });
-        http.accessToken = accessToken;
-        return http.prepareRequest(request)
-          .then(() => {
-            expect(request.headers).toEqual({
-              Authorization: `Bearer ${accessToken.access_token}`
-            });
-          });
-      });
-      it('Requests and sets accessToken if it is not set', () => {
         const http = new Http({ oauth });
         return http.prepareRequest(request)
           .then(() => {
             expect(oauth.getAccessToken).toHaveBeenCalled();
-            expect(http.accessToken).toBe(accessToken);
             expect(request.headers).toEqual({
               Authorization: `Bearer ${accessToken.access_token}`
-            });
-          });
-      });
-      it('Handles API errors', () => {
-        const http = new Http({ oauth });
-        getAccessTokenResponse.status = 401;
-        const errorObj = {
-          errorCode: 'a fake error'
-        };
-        getAccessTokenResponse.text = jest.fn().mockReturnValue(Promise.resolve(JSON.stringify(errorObj)));
-        return http.prepareRequest(request)
-          .catch(err => {
-            expect(err).toBeInstanceOf(OktaApiError);
-            expect(err).toEqual({
-              name: 'OktaApiError',
-              status: 401,
-              errorCode: 'a fake error',
-              errorSummary: '',
-              errorCauses: undefined,
-              errorLink: undefined,
-              errorId: undefined,
-              url: 'http://fakey.local',
-              headers: { fakeHeaders: true },
-              message: 'Okta HTTP 401 a fake error '
-            });
-          });
-      });
-      it('Handles unknown errors', () => {
-        const http = new Http({ oauth });
-        getAccessTokenResponse.status = 500;
-        const errorText = 'an uknown error in plain text';
-        getAccessTokenResponse.text = jest.fn().mockReturnValue(Promise.resolve(errorText));
-        return http.prepareRequest(request)
-          .catch(err => {
-            expect(err).toBeInstanceOf(HttpError);
-            expect(err).toEqual({
-              name: 'HttpError',
-              status: 500,
-              url: 'http://fakey.local',
-              headers: { fakeHeaders: true },
-              message: 'HTTP 500 an uknown error in plain text'
             });
           });
       });
@@ -394,6 +399,58 @@ describe('Http class', () => {
             res: jasmine.any(Object)
           }, jasmine.any(Function));
         });
+    });
+
+    describe('Oauth', () => {
+      it('should get new token and retry request when accessToken is not active any more', () => {
+        expect.assertions(5);
+        requestExecutor = {
+          fetch: jest.fn().mockImplementation((request) => {
+            if (request.headers.Authorization === 'Bearer expired_token') {
+              response.status = 401;
+            } else if (request.headers.Authorization === 'Bearer valid_token') {
+              response.status = 200;
+            }
+            return Promise.resolve(response);
+          })
+        };
+        const oauth = {
+          accessToken: { access_token: 'expired_token' },
+          getAccessToken: jest.fn().mockImplementation(() => {
+            if (oauth.accessToken) {
+              return Promise.resolve(oauth.accessToken);
+            }
+            return Promise.resolve({ access_token: 'valid_token' });
+          }),
+          clearCachedAccessToken: jest.fn().mockImplementation(() => {
+            oauth.accessToken = null;
+          }),
+          introspectAccessToken: jest.fn().mockResolvedValueOnce({ active: false })
+        };
+        const http = new Http({ requestExecutor, oauth });
+        jest.spyOn(http, 'http');
+        return http.http('http://fakey.local')
+          .then(res => {
+            expect(http.http).toHaveBeenCalledTimes(2);
+            expect(oauth.getAccessToken).toHaveBeenCalledTimes(2);
+            expect(oauth.introspectAccessToken).toHaveBeenCalledTimes(1);
+            expect(oauth.clearCachedAccessToken).toHaveBeenCalledTimes(1);
+            expect(res.status).toEqual(200);
+          });
+      });
+      it('should throw error if status is 401, but access token is still active', () => {
+        expect.assertions(1);
+        response.status = 401;
+        const oauth = {
+          getAccessToken: jest.fn().mockResolvedValueOnce({ access_token: 'fake token' }),
+          introspectAccessToken: jest.fn().mockResolvedValueOnce({ active: true })
+        };
+        const http = new Http({ requestExecutor, oauth });
+        return http.http('http://fakey.local')
+          .catch(err => {
+            expect(err).toBeInstanceOf(OktaApiError);
+          });
+      });
     });
   });
 });

--- a/test/jest/jwt.test.js
+++ b/test/jest/jwt.test.js
@@ -43,9 +43,9 @@ describe('JWT', () => {
         baseUrl: 'http://localhost'
       };
     });
-    function verifyJWT(jwt) {
+    function verifyJWT(jwt, endpoint) {
       expect(jwt.body).toEqual({
-        aud: 'http://localhost/oauth2/v1/token',
+        aud: `http://localhost${endpoint}`,
         exp: 300,
         iat: 0,
         iss: 'fake-client-id',
@@ -61,7 +61,7 @@ describe('JWT', () => {
       return Rasha.export({ jwk: JWK, 'public': true }).then(function (publicKey) {
         const verifiedJwt = nJwt.verify(compactedJwt, publicKey, 'RS256');
         expect(verifiedJwt.body).toEqual({
-          aud: 'http://localhost/oauth2/v1/token',
+          aud: `http://localhost${endpoint}`,
           jti: jasmine.any(String),
           iat: 0,
           exp: 300,
@@ -76,16 +76,18 @@ describe('JWT', () => {
     }
     it('creates a valid JWT using PEM', () => {
       client.privateKey = PEM;
-      return JWT.makeJwt(client)
+      const endpoint = '/oauth2/v1/token';
+      return JWT.makeJwt(client, endpoint)
         .then(jwt => {
-          return verifyJWT(jwt);
+          return verifyJWT(jwt, endpoint);
         });
     });
     it('creates a valid JWT using JWK', () => {
       client.privateKey = JWK;
-      return JWT.makeJwt(client)
+      const endpoint = '/oauth2/v1/token';
+      return JWT.makeJwt(client, endpoint)
         .then(jwt => {
-          return verifyJWT(jwt);
+          return verifyJWT(jwt, endpoint);
         });
     });
   });


### PR DESCRIPTION
What's in this PR:
- add refresh access token strategy
- fix error if token is not provided in configure when `authorizationMode` is `PrivateKey`

Fixes  #135 