### PR TITLE
fix: templates to pass request to Collection constructor - OKTA-288633

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -23,12 +23,14 @@ class Collection {
    * @param {ApiClient} client A reference to the top-level api client
    * @param {String} uri E.g. /api/v1/resources
    * @param {Object} Ctor Class of each item in the collection
+   * @param {Request} [request] Fetch API request object
    */
-  constructor(client, uri, factory) {
+  constructor(client, uri, factory, request) {
     this.nextUri = uri;
     this.client = client;
     this.factory = factory;
     this.currentItems = [];
+    this.request = request;
   }
 
   next() {
@@ -64,7 +66,7 @@ class Collection {
   }
 
   getNextPage() {
-    return this.client.http.http(this.nextUri, null, {isCollection: true})
+    return this.client.http.http(this.nextUri, this.request, {isCollection: true})
     .then(res => {
       const link = res.headers.get('link');
       if (link) {

--- a/templates/generated-client.js.hbs
+++ b/templates/generated-client.js.hbs
@@ -28,9 +28,9 @@ class GeneratedApiClient {
 
     {{#if isArray}}
     {{#if responseModelRequiresResolution}}
-    return new Collection(this, url, new factories.{{responseModel}}());
+    return new Collection(this, url, new factories.{{responseModel}}(), {method: '{{method}}'});
     {{else}}
-    return new Collection(this, url, new ModelFactory(models.{{responseModel}}));
+    return new Collection(this, url, new ModelFactory(models.{{responseModel}}), {method: '{{method}}'});
     {{/if}}
     {{else}}
     const resources = {{{getAffectedResources path}}};

--- a/test/unit/collection.js
+++ b/test/unit/collection.js
@@ -67,6 +67,27 @@ describe('Collection', () => {
         expect(collected[1]).to.equal(2);
       });
     });
+
+    it('should pass request object to http client if it has been initialized with constructor', async () => {
+      const noop = () => {};
+      const mockRequest = { method: 'post' };
+      const mockClient = {
+        http: {
+          http: (_, request) => {
+            expect(request).to.deep.equal(mockRequest);
+            return Promise.resolve({
+              headers: { get: noop },
+              json: () => Promise.resolve([1, 2, 3])
+            });
+          }
+        }
+      };
+      const mockFactory = {
+        createInstance: (item) => item
+      };
+      const collection = new Collection(mockClient, '/', mockFactory, mockRequest);
+      await collection.each(noop);
+    });
   });
 
   describe('.subscribe()', () => {


### PR DESCRIPTION
Description:
Pass fetch request object into Collection's constructor to pass request to httpClient.

Resolves: OKTA-288633