### PR TITLE
test: add it for group api - OKTA-288652

### DIFF
--- a/test/it/group-app.js
+++ b/test/it/group-app.js
@@ -1,0 +1,48 @@
+const expect = require('chai').expect;
+const okta = require('../../src');
+const models = require('../../src/models');
+const Collection = require('../../src/collection');
+const utils = require('../utils');
+const mockGroup = require('./mocks/group.json');
+let orgUrl = process.env.OKTA_CLIENT_ORGURL;
+
+if (process.env.OKTA_USE_MOCK) {
+  orgUrl = `${orgUrl}/group-app`;
+}
+
+const client = new okta.Client({
+  orgUrl: orgUrl,
+  token: process.env.OKTA_CLIENT_TOKEN,
+  requestExecutor: new okta.DefaultRequestExecutor()
+});
+
+describe('Group App API', () => {
+  describe('List assigned applications', () => {
+    let application;
+    let group;
+    let groupAssignment;
+    beforeEach(async () => {
+      const mockApplication = utils.getBookmarkApplication();
+      application = await client.createApplication(mockApplication);
+      group = await client.createGroup(mockGroup);
+      groupAssignment = await application.createApplicationGroupAssignment(group.id);
+    });
+    afterEach(async () => {
+      await groupAssignment.delete(application.id);
+      await application.deactivate();
+      await application.delete();
+      await group.delete();
+    });
+
+    it('should return a Collection', async () => {
+      const applications = await group.listApplications();
+      expect(applications).to.be.instanceOf(Collection);
+    });
+
+    it('should resolve Application in collection', async () => {
+      await group.listApplications().each(application => {
+        expect(application).to.be.instanceOf(models.Application);
+      });
+    });
+  });
+});

--- a/test/it/mocks/group.json
+++ b/test/it/mocks/group.json
@@ -1,0 +1,5 @@
+{
+  "profile": {
+    "name": "Application delete group"
+  }
+}


### PR DESCRIPTION
After comparing with existing tests for group API. Looks like the only missing tests are for listAssignedApplicationsForGroup `/api/v1/groups/${groupId}/apps`