### PR TITLE
Fixing off-by-one error in Collection iterator

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -52,7 +52,7 @@ class Collection {
       }
 
       if (!self.nextUri) {
-        resolve({ done: true });
+        resolve({ done: true, value: null });
         return;
       }
 

--- a/src/collection.js
+++ b/src/collection.js
@@ -38,16 +38,22 @@ class Collection {
 
     return new Promise((resolve, reject) => {
       function nextItem() {
-        const item = self.currentItems.shift();
+        const done = !self.currentItems.length && !self.nextUri;
+        const item = self.currentItems.length && self.currentItems.shift();
         const result = {
           value: item ? self.factory.createInstance(item, self.client) : null,
-          done: !self.currentItems.length && !self.nextUri
+          done,
         };
         resolve(result);
       }
 
       if (self.currentItems.length) {
         return nextItem();
+      }
+
+      if (!self.nextUri) {
+        resolve({ done: true });
+        return;
       }
 
       self.getNextPage()

--- a/test/unit/collection.js
+++ b/test/unit/collection.js
@@ -297,6 +297,31 @@ describe('Collection', () => {
     it('should return { done: true } only _after_ all items in the collection have been returned', async () => {
       const mockClient = {
         http: {
+          http: () => {
+            return Promise.resolve({
+              headers: {
+                get: () => {}
+              },
+              json: () => {
+                return Promise.resolve([1, 2, 3]);
+              }
+            });
+          }
+        }
+      };
+      const mockFactory = {
+        createInstance: (item) => item
+      };
+      const collection = new Collection(mockClient, '/', mockFactory);
+      expect(await collection.next()).to.deep.equal({ value: 1, done: false });
+      expect(await collection.next()).to.deep.equal({ value: 2, done: false });
+      expect(await collection.next()).to.deep.equal({ value: 3, done: false });
+      expect(await collection.next()).to.deep.equal({ done: true, value: null });
+    });
+
+    it('should return { done: true } only _after_ all items in the collection have been returned when paginating', async () => {
+      const mockClient = {
+        http: {
           http: (uri) => {
             return Promise.resolve({
               headers: {
@@ -311,7 +336,7 @@ describe('Collection', () => {
                   return Promise.resolve([1]);
                 }
                 if (uri === '/next') {
-                  return Promise.resolve([2]);
+                  return Promise.resolve([2, 3]);
                 }
               }
             });
@@ -324,7 +349,8 @@ describe('Collection', () => {
       const collection = new Collection(mockClient, '/', mockFactory);
       expect(await collection.next()).to.deep.equal({ value: 1, done: false });
       expect(await collection.next()).to.deep.equal({ value: 2, done: false });
-      expect(await collection.next()).to.deep.equal({ done: true });
+      expect(await collection.next()).to.deep.equal({ value: 3, done: false });
+      expect(await collection.next()).to.deep.equal({ done: true, value: null });
     });
   });
 });


### PR DESCRIPTION
## What changed?

- See title; fixed implementation of the [iterator protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#The_iterator_protocol) so the last value is consumed when using `for...of`
  - It now returns `{ done: true }` _after_ the final value is returned, instead of `{ done: true, value: finalValue }`
  - The `.next()` function is also used to implement `.each()`, but the latter wasn't affected by this bug

## Test plan

Unit tests pass