### PR TITLE
fix: set 'kid' JWT header from JWK whenever it is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Okta Node SDK Changelog
 
+## 4.6.0
+
+### Features
+
+- [#237](https://github.com/okta/okta-sdk-nodejs/pull/237) Exposes models and type declarations through library root
+
+### Bug Fixes
+
+- [#247](https://github.com/okta/okta-sdk-nodejs/pull/247) Fixes OAuth flow error for apps using multiple JWKs
+
 ## 4.5.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The `privateKey` can be passed in the following ways:
 - A string in PEM format
 - As a JSON object, in JWK format
 
+> Note: in case OAuth client app uses multiple JWKs, `privateKey` should specify `kid` attribute.
 
 ## Table of Contents
 

--- a/src/jwt.js
+++ b/src/jwt.js
@@ -61,7 +61,9 @@ function makeJwt(client, endpoint) {
         .setExpiration(plus5Minutes)
         .setIssuer(client.clientId)
         .setSubject(client.clientId);
-
+      if (jwk.kid) {
+        jwt = jwt.setHeader('kid', jwk.kid);
+      }
       // JWT object is returned. It needs to be compacted with jwt.compact() before it can be used
       return jwt;
     });

--- a/test/jest/.eslintrc
+++ b/test/jest/.eslintrc
@@ -1,4 +1,7 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 9
+  },
   "globals": {
     "jest/globals": true
   },

--- a/test/jest/jwt.test.js
+++ b/test/jest/jwt.test.js
@@ -95,5 +95,36 @@ describe('JWT', () => {
           return verifyJWT(jwt, endpoint);
         });
     });
+    it('sets JWK\'s \'kid\' value into JWT header', () => {
+      client.privateKey = {
+        ...JWK,
+        kid: 'keyId'
+      };
+      const endpoint = '/oauth2/v1/token';
+      return JWT.makeJwt(client, endpoint)
+        .then(jwt => {
+          return Promise.resolve().then(() => {
+            expect(jwt.header).toEqual({
+              alg: 'RS256',
+              kid: 'keyId',
+              typ: 'JWT'
+            });
+          });
+        });
+    });
+
+    it('does not set \'kid\' JWT header if \'kid\' was not specified in JWK', () => {
+      client.privateKey = JWK;
+      const endpoint = '/oauth2/v1/token';
+      return JWT.makeJwt(client, endpoint)
+        .then(jwt => {
+          return Promise.resolve().then(() => {
+            expect(jwt.header).toEqual({
+              alg: 'RS256',
+              typ: 'JWT'
+            });
+          });
+        });
+    });
   });
 });


### PR DESCRIPTION
* use `kid` value from parsed JWK (there _seem_ to be no value in passing it as a standalone configuration parameter)

Resolves [OKTA-386883](https://oktainc.atlassian.net/browse/OKTA-386883) (https://github.com/okta/okta-sdk-nodejs/issues/223).

