### PR TITLE
fix: @types dependencies should be devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,6 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/okta/okta-sdk-nodejs",
   "dependencies": {
-    "@types/node-fetch": "^2.5.8",
-    "@types/rasha": "^1.2.2",
     "deep-copy": "^1.4.2",
     "isomorphic-fetch": "^3.0.0",
     "js-yaml": "^4.1.0",
@@ -46,6 +44,8 @@
     "@okta/openapi": "^2.7.2",
     "@types/chai": "^4.2.17",
     "@types/mocha": "^8.2.2",
+    "@types/node-fetch": "^2.5.8",
+    "@types/rasha": "^1.2.2",
     "@typescript-eslint/eslint-plugin": "^4.15.2",
     "@typescript-eslint/parser": "^4.15.2",
     "chai": "^4.2.0",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our [guidelines](/okta/okta-sdk-nodejs/blob/master/CONTRIBUTING.md)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `@types/...` dependencies are used for compilation and should not be added to runtime.
It can create conflict in this case @types/node-fetch is not useful anymore with `node-fetch >= 3.0` (https://www.npmjs.com/package/node-fetch)

If you have a project using `node-fetch >= 3.0` and having `okta-sdk-nodejs` as dependency it will prevent the project to build


## What is the new behavior?
Move `@types/...` dependencies to devDependencies

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


## Other information


## Reviewers

