### PR TITLE
Added filter and pagination integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "test:ci:unit": "MOCHA_FILE=./test-reports/junit-results.xml nyc --reporter=text --reporter=html mocha --reporter=mocha-junit-reporter test/unit/*.js --no-timeouts",
     "test:types": "tsd && tsc --noEmit --isolatedModules --importsNotUsedAsValues error src/types/**/*.ts",
     "test": "yarn eslint && yarn test:types && yarn test:unit && yarn test:integration && yarn jest",
-    "aftertest": "mocha test/delete-resources.js --no-timeouts"
+    "aftertest": "mocha test/delete-resources.js --no-timeouts",
+    "validate:v2-v3": "node scripts/validate.js ./spec/management.yaml"
   },
   "keywords": [],
   "license": "Apache-2.0",
@@ -79,7 +80,8 @@
     "ts-node": "^10.4.0",
     "tsconfig-paths": "^3.11.0",
     "tsd": "^0.18.0",
-    "typescript": "^4.4.4"
+    "typescript": "^4.4.4",
+    "@apidevtools/swagger-parser": "^10.1.0"
   },
   "resolutions": {
     "node-fetch": "^2.6.7",

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -1,39 +1,39 @@
 const _ = require('lodash');
-const SwaggerParser = require("@apidevtools/swagger-parser");
+const SwaggerParser = require('@apidevtools/swagger-parser');
 const spec2 = require('../node_modules/@okta/openapi/dist/spec.json');
 
 (async () => {
-    const spec3 = await SwaggerParser.dereference(process.argv[2] || "spec/management.yaml");
-    const ops = {};
-    
-    for (const path in spec2.paths) {
-        for (const method in spec2.paths[path]) {
-            const op = spec2.paths[path][method];
-            ops[op.operationId] = {};
-            ops[op.operationId]['v2'] = op;
-        }
-    }
+  const spec3 = await SwaggerParser.dereference(process.argv[2] || 'spec/management.yaml');
+  const ops = {};
 
-    for (const path in spec3.paths) {
-        for (const method in spec3.paths[path]) {
-            const op = spec3.paths[path][method];
-            if (!ops[op.operationId]) {
-                ops[op.operationId] = {};
-            }
-            ops[op.operationId]['v3'] = op;
-        }
+  for (const path in spec2.paths) {
+    for (const method in spec2.paths[path]) {
+      const op = spec2.paths[path][method];
+      ops[op.operationId] = {};
+      ops[op.operationId]['v2'] = op;
     }
+  }
 
-    for (const opId in ops) {
-        const op = ops[opId];
-        if (op.v2 && !op.v3) {
-            console.warn(`${opId} - missing in v3`);
-        } else if (op.v2 && op.v3) {
-            const queryParams2 = op.v2.parameters.filter(p => p.in === 'query').map(p => p.name);
-            const queryParams3 = (op.v3.parameters || []).filter(p => p.in === 'query').map(p => p.name);
-            if (!_.isEqual(queryParams2, queryParams3)) {
-                console.error(`${opId} - incompatible query params: v2 has ${queryParams2}, v3 has ${queryParams3}`);
-            }
-        }
+  for (const path in spec3.paths) {
+    for (const method in spec3.paths[path]) {
+      const op = spec3.paths[path][method];
+      if (!ops[op.operationId]) {
+        ops[op.operationId] = {};
+      }
+      ops[op.operationId]['v3'] = op;
     }
+  }
+
+  for (const opId in ops) {
+    const op = ops[opId];
+    if (op.v2 && !op.v3) {
+      console.warn(`${opId} - missing in v3`);
+    } else if (op.v2 && op.v3) {
+      const queryParams2 = op.v2.parameters.filter(p => p.in === 'query').map(p => p.name);
+      const queryParams3 = (op.v3.parameters || []).filter(p => p.in === 'query').map(p => p.name);
+      if (!_.isEqual(queryParams2, queryParams3)) {
+        console.error(`${opId} - incompatible query params: v2 has ${queryParams2}, v3 has ${queryParams3}`);
+      }
+    }
+  }
 })();

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -1,0 +1,39 @@
+const _ = require('lodash');
+const SwaggerParser = require("@apidevtools/swagger-parser");
+const spec2 = require('../node_modules/@okta/openapi/dist/spec.json');
+
+(async () => {
+    const spec3 = await SwaggerParser.dereference(process.argv[2] || "spec/management.yaml");
+    const ops = {};
+    
+    for (const path in spec2.paths) {
+        for (const method in spec2.paths[path]) {
+            const op = spec2.paths[path][method];
+            ops[op.operationId] = {};
+            ops[op.operationId]['v2'] = op;
+        }
+    }
+
+    for (const path in spec3.paths) {
+        for (const method in spec3.paths[path]) {
+            const op = spec3.paths[path][method];
+            if (!ops[op.operationId]) {
+                ops[op.operationId] = {};
+            }
+            ops[op.operationId]['v3'] = op;
+        }
+    }
+
+    for (const opId in ops) {
+        const op = ops[opId];
+        if (op.v2 && !op.v3) {
+            console.warn(`${opId} - missing in v3`);
+        } else if (op.v2 && op.v3) {
+            const queryParams2 = op.v2.parameters.filter(p => p.in === 'query').map(p => p.name);
+            const queryParams3 = (op.v3.parameters || []).filter(p => p.in === 'query').map(p => p.name);
+            if (!_.isEqual(queryParams2, queryParams3)) {
+                console.error(`${opId} - incompatible query params: v2 has ${queryParams2}, v3 has ${queryParams3}`);
+            }
+        }
+    }
+})();

--- a/test/it/application-user-schema.ts
+++ b/test/it/application-user-schema.ts
@@ -3,7 +3,6 @@ import { expect } from 'chai';
 import utils = require('../utils');
 import {
   Client,
-  BookmarkApplication,
   DefaultRequestExecutor,
   v3,
 } from '@okta/okta-sdk-nodejs';

--- a/test/it/authserver-crud.ts
+++ b/test/it/authserver-crud.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { spy } from 'sinon';
 import {
   v3,
   Client,
@@ -69,12 +70,15 @@ describe('Authorization Server Crud API', () => {
         limit: '1'
       };
       const filtered = new Set();
-      await (await client.listAuthorizationServers(queryParameters)).each(as => {
+      const collection = await client.listAuthorizationServers(queryParameters);
+      const pageSpy = spy(collection, 'getNextPage');
+      await collection.each(as => {
         expect(as).to.be.an.instanceof(v3.AuthorizationServer);
         expect(as.name).to.match(new RegExp(queryParameters.q));
         expect(filtered.has(as.name)).to.be.false;
         filtered.add(as.name);
       });
+      expect(pageSpy.getCalls().length).to.be.greaterThanOrEqual(2);
       expect(filtered.size).to.equal(2);
     });
   });

--- a/test/it/authserver-crud.ts
+++ b/test/it/authserver-crud.ts
@@ -65,7 +65,7 @@ describe('Authorization Server Crud API', () => {
     it('should search with q and paginate results', async () => {
       const queryParameters = {
         q: 'node-sdk: AUTH_SRV_AB',
-        // TODO: OKTA-512396 - limit should be number
+        // TODO: OKTA-515269 - limit should be number
         limit: '1'
       };
       const filtered = new Set();

--- a/test/it/authserver-scope.ts
+++ b/test/it/authserver-scope.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { spy } from 'sinon';
 import {
   Client,
   Collection,
@@ -78,17 +79,22 @@ describe('Authorization Server Scope API', () => {
       }
     });
 
-    it('should paginate results', async () => {
+    // Pagination does not work
+    xit('should paginate results', async () => {
       const filtered = new Set();
-      await (await client.listOAuth2Scopes(authServer.id, { limit: 2 })).each(scope => {
+      const collection = await client.listOAuth2Scopes(authServer.id, {
+        limit: 2
+      });
+      const pageSpy = spy(collection, 'getNextPage');
+      await collection.each(scope => {
         expect(scope).to.be.an.instanceof(v3.OAuth2Scope);
         expect(filtered.has(scope.name)).to.be.false;
         filtered.add(scope.name);
       });
       expect(filtered.size).to.be.greaterThanOrEqual(4);
+      expect(pageSpy.getCalls().length).to.equal(2);
     });
 
-    // Pagination does not work with q
     // `filter` does not work? Not documented.
     it('should search with q', async () => {
       const queryParameters = {

--- a/test/it/authserver-scope.ts
+++ b/test/it/authserver-scope.ts
@@ -7,6 +7,7 @@ import {
 } from '@okta/okta-sdk-nodejs';
 import getMockAuthorizationServer = require('./mocks/authorization-server');
 import mockScope = require('./mocks/scope.json');
+import faker = require('@faker-js/faker');
 let orgUrl = process.env.OKTA_CLIENT_ORGURL;
 
 if (process.env.OKTA_USE_MOCK) {
@@ -47,6 +48,60 @@ describe('Authorization Server Scope API', () => {
       const scopeFindByName = scopes.find(s => s.name === mockScope.name);
       expect(scopeFindByName).to.be.exist;
       expect(scopeFindByName).to.be.instanceOf(v3.OAuth2Scope);
+    });
+  });
+
+  describe('Filter scopes', () => {
+    let scopes: Array<v3.OAuth2Scope>;
+    before(async () => {
+      scopes = [];
+      const namePrefixes = [
+        'nodesdk1',
+        'nodesdk2',
+      ];
+      for (const prefix of namePrefixes) {
+        for (let i = 0 ; i < 2 ; i++) {
+          const suf = faker.random.word();
+          const mockScope = {
+            name: `${prefix}:${suf}`,
+            description: suf,
+            consent: 'REQUIRED'
+          };
+          const scope = await client.createOAuth2Scope(authServer.id, mockScope as v3.OAuth2Scope);
+          scopes.push(scope);
+        }
+      }
+    });
+    after(async () => {
+      for (const scope of scopes) {
+        await client.deleteOAuth2Scope(authServer.id, scope.id);
+      }
+    });
+
+    it('should paginate results', async () => {
+      const filtered = new Set();
+      await (await client.listOAuth2Scopes(authServer.id, { limit: 2 })).each(scope => {
+        expect(scope).to.be.an.instanceof(v3.OAuth2Scope);
+        expect(filtered.has(scope.name)).to.be.false;
+        filtered.add(scope.name);
+      });
+      expect(filtered.size).to.be.greaterThanOrEqual(4);
+    });
+
+    // Pagination does not work with q
+    // `filter` does not work? Not documented.
+    it('should search with q', async () => {
+      const queryParameters = {
+        q: 'nodesdk1'
+      };
+      const filtered = new Set();
+      await (await client.listOAuth2Scopes(authServer.id, queryParameters)).each(scope => {
+        expect(scope).to.be.an.instanceof(v3.OAuth2Scope);
+        expect(scope.name).to.match(new RegExp(queryParameters.q));
+        expect(filtered.has(scope.name)).to.be.false;
+        filtered.add(scope.name);
+      });
+      expect(filtered.size).to.equal(2);
     });
   });
 

--- a/test/it/client-get-logs.ts
+++ b/test/it/client-get-logs.ts
@@ -20,6 +20,46 @@ const client = new Client({
 
 describe('client.getLogs()', () => {
 
+  it('should search with q and paginate results', async () => {
+    const max = 10, limit = 5;
+    const collection = await client.getLogs({
+      since: '2018-01-26T00:00:00Z',
+      until: '2038-01-26T00:00:00Z',
+      q: 'user',
+      sortOrder: 'DESCENDING',
+      limit
+    });
+    let cnt = 0;
+    await collection.each(log => {
+      expect(log).to.be.instanceof(v3.LogEvent);
+      cnt++;
+      if (cnt >= max) {
+        return false;
+      }
+    });
+    expect(cnt).to.be.lessThanOrEqual(max);
+  });
+
+  it('should filter with filter and paginate results', async () => {
+    const max = 10, limit = 5;
+    const collection = await client.getLogs({
+      since: '2018-01-26T00:00:00Z',
+      until: '2038-01-26T00:00:00Z',
+      filter: 'severity eq "INFO"',
+      sortOrder: 'DESCENDING',
+      limit
+    });
+    let cnt = 0;
+    await collection.each(log => {
+      expect(log).to.be.instanceof(v3.LogEvent);
+      cnt++;
+      if (cnt >= max) {
+        return false;
+      }
+    });
+    expect(cnt).to.be.lessThanOrEqual(max);
+  });
+
   it('should allow me to poll the collection but stop when needed', async () => {
     const collection = await client.getLogs({ since: '2018-01-26T00:00:00Z'});
     let iteratorCalledTimes = 0;

--- a/test/it/client-get-logs.ts
+++ b/test/it/client-get-logs.ts
@@ -1,9 +1,10 @@
 import { expect } from 'chai';
-
+import { spy } from 'sinon';
 import {
   Client,
   DefaultRequestExecutor,
-  v3 } from '@okta/okta-sdk-nodejs';
+  v3
+} from '@okta/okta-sdk-nodejs';
 
 let orgUrl = process.env.OKTA_CLIENT_ORGURL;
 
@@ -29,6 +30,7 @@ describe('client.getLogs()', () => {
       sortOrder: 'DESCENDING',
       limit
     });
+    const pageSpy = spy(collection, 'getNextPage');
     let cnt = 0;
     await collection.each(log => {
       expect(log).to.be.instanceof(v3.LogEvent);
@@ -38,6 +40,7 @@ describe('client.getLogs()', () => {
       }
     });
     expect(cnt).to.be.lessThanOrEqual(max);
+    expect(pageSpy.getCalls().length).to.be.greaterThanOrEqual(Math.ceil(cnt / limit));
   });
 
   it('should filter with filter and paginate results', async () => {
@@ -49,6 +52,7 @@ describe('client.getLogs()', () => {
       sortOrder: 'DESCENDING',
       limit
     });
+    const pageSpy = spy(collection, 'getNextPage');
     let cnt = 0;
     await collection.each(log => {
       expect(log).to.be.instanceof(v3.LogEvent);
@@ -58,6 +62,7 @@ describe('client.getLogs()', () => {
       }
     });
     expect(cnt).to.be.lessThanOrEqual(max);
+    expect(pageSpy.getCalls().length).to.be.greaterThanOrEqual(Math.ceil(cnt / limit));
   });
 
   it('should allow me to poll the collection but stop when needed', async () => {

--- a/test/it/client-list-application-group-assignment.ts
+++ b/test/it/client-list-application-group-assignment.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { spy } from 'sinon';
 import faker = require('@faker-js/faker');
 
 import {
@@ -100,12 +101,16 @@ describe('client.listApplicationGroupAssignments({ })', () => {
 
   it('should paginate results', async () => {
     const listIds = new Set();
-    const collection = await client.listApplicationGroupAssignments(app.id, { limit: 2 });
+    const collection = await client.listApplicationGroupAssignments(app.id, {
+      limit: 2
+    });
+    const pageSpy = spy(collection, 'getNextPage');
     await collection.each(async assignment => {
       expect(listIds.has(assignment.id)).to.be.false;
       listIds.add(assignment.id);
     });
     expect(listIds.size).to.equal(3);
+    expect(pageSpy.getCalls().length).to.equal(2);
   });
 
   it('should search groups with q and paginate results', async () => {
@@ -113,10 +118,13 @@ describe('client.listApplicationGroupAssignments({ })', () => {
       q: 'client-list-app-groups-filtered',
       limit: 1
     };
+    const collection = await client.listApplicationGroupAssignments(app.id, queryParameters);
+    const pageSpy = spy(collection, 'getNextPage');
     const filteredIds = new Set();
-    await (await client.listApplicationGroupAssignments(app.id, queryParameters)).each(assignment => {
+    await collection.each(assignment => {
       filteredIds.add(assignment.id);
     });
     expect(filteredIds.size).to.equal(2);
+    expect(pageSpy.getCalls().length).to.equal(2);
   });
 });

--- a/test/it/client-list-application-users.ts
+++ b/test/it/client-list-application-users.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { spy } from 'sinon';
 
 import {
   Client,
@@ -118,12 +119,16 @@ describe('client.listApplicationUsers({ })', () => {
 
   it('should paginate results', async () => {
     const listIds = new Set();
-    const collection = await client.listApplicationUsers(app.id, { limit: 2 });
+    const collection = await client.listApplicationUsers(app.id, {
+      limit: 2
+    });
+    const pageSpy = spy(collection, 'getNextPage');
     await collection.each(async appUser => {
       expect(listIds.has(appUser.id)).to.be.false;
       listIds.add(appUser.id);
     });
     expect(listIds.size).to.equal(3);
+    expect(pageSpy.getCalls().length).to.equal(2);
   });
 
   it('should search users with q and paginate results', async () => {
@@ -131,11 +136,14 @@ describe('client.listApplicationUsers({ })', () => {
       q: 'client-list-app-users-filtered',
       limit: 1
     };
+    const collection = await client.listApplicationUsers(app.id, queryParameters);
+    const pageSpy = spy(collection, 'getNextPage');
     const filteredIds = new Set();
-    await (await client.listApplicationUsers(app.id, queryParameters)).each(appUser => {
+    await collection.each(appUser => {
       expect(appUser).to.be.an.instanceof(v3.AppUser);
       filteredIds.add(appUser.id);
     });
     expect(filteredIds.size).to.equal(2);
+    expect(pageSpy.getCalls().length).to.equal(2);
   });
 });

--- a/test/it/client-list-application-users.ts
+++ b/test/it/client-list-application-users.ts
@@ -83,18 +83,18 @@ describe('client.listApplicationUsers({ })', () => {
     const createdUser = await client.createUser(newUser);
     return createdUser;
   };
-  
+
   before(async () => {
     const application = utils.getBookmarkApplication();
     await utils.removeAppByLabel(client, application.label);
     app = await client.createApplication(application);
 
-    users.push(await createUser(`client-list-app-users-unassigned`));
-    users.push(await createUser(`client-list-app-users`));
-    users.push(await createUser(`client-list-app-users-filtered-1`));
-    users.push(await createUser(`client-list-app-users-filtered-2`));
+    users.push(await createUser('client-list-app-users-unassigned'));
+    users.push(await createUser('client-list-app-users'));
+    users.push(await createUser('client-list-app-users-filtered-1'));
+    users.push(await createUser('client-list-app-users-filtered-2'));
 
-    for (let user of users.slice(1)) {
+    for (const user of users.slice(1)) {
       const appUser = await client.assignUserToApplication(app.id, {
         id: user.id
       });
@@ -106,7 +106,7 @@ describe('client.listApplicationUsers({ })', () => {
   });
 
   after(async () => {
-    for (let appUser of appUsers) {
+    for (const appUser of appUsers) {
       await client.deleteApplicationUser(app.id, appUser.id);
     }
 
@@ -117,7 +117,7 @@ describe('client.listApplicationUsers({ })', () => {
   });
 
   it('should paginate results', async () => {
-    let listIds = new Set();
+    const listIds = new Set();
     const collection = await client.listApplicationUsers(app.id, { limit: 2 });
     await collection.each(async appUser => {
       expect(listIds.has(appUser.id)).to.be.false;
@@ -131,7 +131,7 @@ describe('client.listApplicationUsers({ })', () => {
       q: 'client-list-app-users-filtered',
       limit: 1
     };
-    let filteredIds = new Set();
+    const filteredIds = new Set();
     await (await client.listApplicationUsers(app.id, queryParameters)).each(appUser => {
       expect(appUser).to.be.an.instanceof(v3.AppUser);
       filteredIds.add(appUser.id);

--- a/test/it/client-list-applications.ts
+++ b/test/it/client-list-applications.ts
@@ -113,7 +113,7 @@ describe('client.listApplications({ })', () => {
     }
   });
 
-  it('should filter apps with filrer and paginate results', async () => {
+  it('should filter apps with filter and paginate results', async () => {
     const queryParameters = {
       filter: `name eq "bookmark"`,
       limit: 2
@@ -128,8 +128,11 @@ describe('client.listApplications({ })', () => {
     expect(filtered.size).to.equal(3);
   });
 
-  it('should search apps with q by name and label', async () => {
-    const queryParameters = { q: 'node-sdk: Filter Sample Basic Auth App' };
+  it('should search apps with q by name and label and paginate results', async () => {
+    const queryParameters = {
+      q: 'node-sdk: Filter Sample Basic Auth App',
+      limit: 1
+    };
     let filtered = new Set();
     await (await client.listApplications(queryParameters)).each(app => {
       expect(app).to.be.an.instanceof(v3.BasicAuthApplication);

--- a/test/it/client-list-applications.ts
+++ b/test/it/client-list-applications.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { spy } from 'sinon';
 import faker = require('@faker-js/faker');
 import {
   v3,
@@ -118,14 +119,17 @@ describe('client.listApplications({ })', () => {
       filter: 'name eq "bookmark"',
       limit: 1
     };
+    const collection = await client.listApplications(queryParameters);
+    const pageSpy = spy(collection, 'getNextPage');
     const filtered = new Set();
-    await (await client.listApplications(queryParameters)).each(app => {
+    await collection.each(app => {
       expect(app).to.be.an.instanceof(v3.BookmarkApplication);
       expect((app as v3.BookmarkApplication).name).to.eq('bookmark');
       expect(filtered.has(app.label)).to.be.false;
       filtered.add(app.label);
     });
     expect(filtered.size).to.equal(2);
+    expect(pageSpy.getCalls().length).to.equal(2);
   });
 
   it('should search apps with q by name and label and paginate results', async () => {
@@ -133,14 +137,17 @@ describe('client.listApplications({ })', () => {
       q: 'node-sdk: Filter Sample Basic Auth App',
       limit: 1
     };
+    const collection = await client.listApplications(queryParameters);
+    const pageSpy = spy(collection, 'getNextPage');
     const filtered = new Set();
-    await (await client.listApplications(queryParameters)).each(app => {
+    await collection.each(app => {
       expect(app).to.be.an.instanceof(v3.BasicAuthApplication);
       expect(app.label).to.match(new RegExp('node-sdk: Filter Sample Basic Auth App'));
       expect(filtered.has(app.label)).to.be.false;
       filtered.add(app.label);
     });
     expect(filtered.size).to.equal(2);
+    expect(pageSpy.getCalls().length).to.equal(2);
   });
 
 });

--- a/test/it/client-list-applications.ts
+++ b/test/it/client-list-applications.ts
@@ -93,7 +93,7 @@ describe('client.listApplications({ })', () => {
   const apps = [];
 
   before(async () => {
-    const stagedApp = await createBookmarkApp('STAGED');
+    const stagedApp = await createBookmarkApp();
     await client.deactivateApplication(stagedApp.id);
     apps.push(stagedApp);
     for (let i = 0 ; i < 2 ; i++) {

--- a/test/it/client-list-applications.ts
+++ b/test/it/client-list-applications.ts
@@ -20,7 +20,7 @@ const client = new Client({
   requestExecutor: new DefaultRequestExecutor()
 });
 
-const createBookmarkApp = async (name?: string) => {
+const createBookmarkApp = async () => {
   const app: v3.BookmarkApplication = {
     name: 'bookmark',
     label: `node-sdk: Filter Bookmark App ${faker.random.word()}`.substring(0, 49),
@@ -36,7 +36,7 @@ const createBookmarkApp = async (name?: string) => {
   return await client.createApplication(app);
 };
 
-const createBasicAuthApp = async (name?: string) => {
+const createBasicAuthApp = async () => {
   const app: v3.BasicAuthApplication = {
     name: 'template_basic_auth',
     label: `node-sdk: Filter Sample Basic Auth App ${faker.random.word()}`.substring(0, 49),
@@ -107,7 +107,7 @@ describe('client.listApplications({ })', () => {
   });
 
   after(async () => {
-    for (let app of apps) {
+    for (const app of apps) {
       await client.deactivateApplication(app.id);
       await client.deleteApplication(app.id);
     }
@@ -115,10 +115,10 @@ describe('client.listApplications({ })', () => {
 
   it('should filter apps with filter and paginate results', async () => {
     const queryParameters = {
-      filter: `name eq "bookmark"`,
+      filter: 'name eq "bookmark"',
       limit: 2
     };
-    let filtered = new Set();
+    const filtered = new Set();
     await (await client.listApplications(queryParameters)).each(app => {
       expect(app).to.be.an.instanceof(v3.BookmarkApplication);
       expect((app as v3.BookmarkApplication).name).to.eq('bookmark');
@@ -133,7 +133,7 @@ describe('client.listApplications({ })', () => {
       q: 'node-sdk: Filter Sample Basic Auth App',
       limit: 1
     };
-    let filtered = new Set();
+    const filtered = new Set();
     await (await client.listApplications(queryParameters)).each(app => {
       expect(app).to.be.an.instanceof(v3.BasicAuthApplication);
       expect(app.label).to.match(new RegExp('node-sdk: Filter Sample Basic Auth App'));

--- a/test/it/client-list-applications.ts
+++ b/test/it/client-list-applications.ts
@@ -100,7 +100,7 @@ describe('client.listApplications({ })', () => {
       const app = await createBasicAuthApp();
       apps.push(app);
     }
-    for (let i = 0 ; i < 2 ; i++) {
+    for (let i = 0 ; i < 1 ; i++) {
       const app = await createBookmarkApp();
       apps.push(app);
     }
@@ -116,7 +116,7 @@ describe('client.listApplications({ })', () => {
   it('should filter apps with filter and paginate results', async () => {
     const queryParameters = {
       filter: 'name eq "bookmark"',
-      limit: 2
+      limit: 1
     };
     const filtered = new Set();
     await (await client.listApplications(queryParameters)).each(app => {
@@ -125,7 +125,7 @@ describe('client.listApplications({ })', () => {
       expect(filtered.has(app.label)).to.be.false;
       filtered.add(app.label);
     });
-    expect(filtered.size).to.equal(3);
+    expect(filtered.size).to.equal(2);
   });
 
   it('should search apps with q by name and label and paginate results', async () => {

--- a/test/it/client-list-applications.ts
+++ b/test/it/client-list-applications.ts
@@ -113,7 +113,7 @@ describe('client.listApplications({ })', () => {
     }
   });
 
-  it('should filter apps with pagination', async () => {
+  it('should filter apps with filrer and paginate results', async () => {
     const queryParameters = {
       filter: `name eq "bookmark"`,
       limit: 2

--- a/test/it/client-list-users.ts
+++ b/test/it/client-list-users.ts
@@ -77,7 +77,7 @@ describe('client.listUsers({ })', () => {
     const newUser = {
       profile: {
         ...utils.getMockProfile(name),
-        lastName: 'okta-sdk-nodejs-filter',
+        lastName: 'okta-sdk-nodejs-users-filter',
       },
       credentials: {
         password: {value: 'Abcd1234#@'}
@@ -105,13 +105,13 @@ describe('client.listUsers({ })', () => {
 
   it('should filter users with filter and paginate results', async () => {
     const queryParameters = {
-      filter: `status eq "ACTIVE" AND profile.lastName eq "okta-sdk-nodejs-filter"`,
+      filter: `status eq "ACTIVE" AND profile.lastName eq "okta-sdk-nodejs-users-filter"`,
       limit: 2
     };
     let filtered = new Set();
     await (await client.listUsers(queryParameters)).each(user => {
       expect(user).to.be.an.instanceof(v3.User);
-      expect(user.profile.lastName).to.eq('okta-sdk-nodejs-filter');
+      expect(user.profile.lastName).to.eq('okta-sdk-nodejs-users-filter');
       expect(filtered.has(user.profile.firstName)).to.be.false;
       filtered.add(user.profile.firstName);
     });
@@ -120,20 +120,20 @@ describe('client.listUsers({ })', () => {
 
   it('should filter users with search and paginate results', async () => {
     const queryParameters = {
-      search: `status eq "ACTIVE" AND profile.lastName eq "okta-sdk-nodejs-filter"`,
+      search: `status eq "ACTIVE" AND profile.lastName eq "okta-sdk-nodejs-users-filter"`,
       limit: 2
     };
     let filtered = new Set();
     await (await client.listUsers(queryParameters)).each(user => {
       expect(user).to.be.an.instanceof(v3.User);
-      expect(user.profile.lastName).to.eq('okta-sdk-nodejs-filter');
+      expect(user.profile.lastName).to.eq('okta-sdk-nodejs-users-filter');
       expect(filtered.has(user.profile.firstName)).to.be.false;
       filtered.add(user.profile.firstName);
     });
     expect(filtered.size).to.equal(3);
   });
 
-  // TODO: q and limit are messed up
+  // TODO: q and limit are messed up !!!
   it('should search users with q', async () => {
     const queryParameters = {
       q: 'client-list-users-filtered'

--- a/test/it/client-list-users.ts
+++ b/test/it/client-list-users.ts
@@ -87,14 +87,14 @@ describe('client.listUsers({ })', () => {
     const createdUser = await client.createUser(newUser);
     return createdUser;
   };
-  
+
   before(async () => {
     const stagedUser = await createUser('client-list-users-staged');
     await client.deactivateUser(stagedUser.id);
     users.push(stagedUser);
-    users.push(await createUser(`client-list-users`));
-    users.push(await createUser(`client-list-users-filtered-1`));
-    users.push(await createUser(`client-list-users-filtered-2`));
+    users.push(await createUser('client-list-users'));
+    users.push(await createUser('client-list-users-filtered-1'));
+    users.push(await createUser('client-list-users-filtered-2'));
     // The search indexing is not instant, so give it some time to settle
     await utils.delay(5000);
   });
@@ -105,10 +105,10 @@ describe('client.listUsers({ })', () => {
 
   it('should filter users with filter and paginate results', async () => {
     const queryParameters = {
-      filter: `status eq "ACTIVE" AND profile.lastName eq "okta-sdk-nodejs-users-filter"`,
+      filter: 'status eq "ACTIVE" AND profile.lastName eq "okta-sdk-nodejs-users-filter"',
       limit: 2
     };
-    let filtered = new Set();
+    const filtered = new Set();
     await (await client.listUsers(queryParameters)).each(user => {
       expect(user).to.be.an.instanceof(v3.User);
       expect(user.profile.lastName).to.eq('okta-sdk-nodejs-users-filter');
@@ -120,10 +120,10 @@ describe('client.listUsers({ })', () => {
 
   it('should filter users with search and paginate results', async () => {
     const queryParameters = {
-      search: `status eq "ACTIVE" AND profile.lastName eq "okta-sdk-nodejs-users-filter"`,
+      search: 'status eq "ACTIVE" AND profile.lastName eq "okta-sdk-nodejs-users-filter"',
       limit: 2
     };
-    let filtered = new Set();
+    const filtered = new Set();
     await (await client.listUsers(queryParameters)).each(user => {
       expect(user).to.be.an.instanceof(v3.User);
       expect(user.profile.lastName).to.eq('okta-sdk-nodejs-users-filter');
@@ -138,7 +138,7 @@ describe('client.listUsers({ })', () => {
     const queryParameters = {
       q: 'client-list-users-filtered'
     };
-    let filtered = new Set();
+    const filtered = new Set();
     await (await client.listUsers(queryParameters)).each(user => {
       expect(user).to.be.an.instanceof(v3.User);
       expect(user.profile.firstName).to.match(new RegExp('client-list-users-filtered'));

--- a/test/it/client-list-users.ts
+++ b/test/it/client-list-users.ts
@@ -1,10 +1,12 @@
 import { expect } from 'chai';
+import { spy } from 'sinon';
 
 import {
   Client,
   Collection,
   DefaultRequestExecutor,
-  v3 } from '@okta/okta-sdk-nodejs';
+  v3
+} from '@okta/okta-sdk-nodejs';
 
 import utils = require('../utils');
 let orgUrl = process.env.OKTA_CLIENT_ORGURL;
@@ -108,14 +110,17 @@ describe('client.listUsers({ })', () => {
       filter: 'status eq "ACTIVE" AND profile.lastName eq "okta-sdk-nodejs-users-filter"',
       limit: 2
     };
+    const collection = await client.listUsers(queryParameters);
+    const pageSpy = spy(collection, 'getNextPage');
     const filtered = new Set();
-    await (await client.listUsers(queryParameters)).each(user => {
+    await collection.each(user => {
       expect(user).to.be.an.instanceof(v3.User);
       expect(user.profile.lastName).to.eq('okta-sdk-nodejs-users-filter');
       expect(filtered.has(user.profile.firstName)).to.be.false;
       filtered.add(user.profile.firstName);
     });
     expect(filtered.size).to.equal(3);
+    expect(pageSpy.getCalls().length).to.equal(2);
   });
 
   it('should filter users with search and paginate results', async () => {
@@ -123,14 +128,17 @@ describe('client.listUsers({ })', () => {
       search: 'status eq "ACTIVE" AND profile.lastName eq "okta-sdk-nodejs-users-filter"',
       limit: 2
     };
+    const collection = await client.listUsers(queryParameters);
+    const pageSpy = spy(collection, 'getNextPage');
     const filtered = new Set();
-    await (await client.listUsers(queryParameters)).each(user => {
+    await collection.each(user => {
       expect(user).to.be.an.instanceof(v3.User);
       expect(user.profile.lastName).to.eq('okta-sdk-nodejs-users-filter');
       expect(filtered.has(user.profile.firstName)).to.be.false;
       filtered.add(user.profile.firstName);
     });
     expect(filtered.size).to.equal(3);
+    expect(pageSpy.getCalls().length).to.equal(2);
   });
 
   // TODO: OKTA-515269 - incompatibility in v2 and v3 specs

--- a/test/it/client-list-users.ts
+++ b/test/it/client-list-users.ts
@@ -133,7 +133,7 @@ describe('client.listUsers({ })', () => {
     expect(filtered.size).to.equal(3);
   });
 
-  // TODO: OKTA-512396 - incompatibility in v2 and v3 specs
+  // TODO: OKTA-515269 - incompatibility in v2 and v3 specs
   xit('should search users with q', async () => {
     const queryParameters = {
       q: 'client-list-users-filtered'

--- a/test/it/client-list-users.ts
+++ b/test/it/client-list-users.ts
@@ -133,8 +133,8 @@ describe('client.listUsers({ })', () => {
     expect(filtered.size).to.equal(3);
   });
 
-  // TODO: q and limit are messed up !!!
-  it('should search users with q', async () => {
+  // TODO: OKTA-512396 - incompatibility in v2 and v3 specs
+  xit('should search users with q', async () => {
     const queryParameters = {
       q: 'client-list-users-filtered'
     };

--- a/test/it/group-rule-operations.ts
+++ b/test/it/group-rule-operations.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { spy } from 'sinon';
 import faker = require('@faker-js/faker');
 
 import utils = require('../utils');
@@ -93,15 +94,18 @@ describe('Group-Rule API tests', () => {
 
     // 3b. Search group rules with pagination
     const filtered = new Set();
-    await (await client.listGroupRules({
+    const collection = await client.listGroupRules({
       search: 'RULE_AB',
       limit: 1
-    })).each(rule => {
+    });
+    const pageSpy = spy(collection, 'getNextPage');
+    await collection.each(rule => {
       expect(filtered.has(rule.name)).to.be.false;
       filtered.add(rule.name);
       expect(rule.name.indexOf('RULE_AB')).to.not.equal(-1);
     });
     expect(filtered.size).to.equal(2);
+    expect(pageSpy.getCalls().length).to.equal(2);
 
     // 4. Verify first rule executes
     // We wait for 30 seconds for the rule to activate i.e. userInGroup = true

--- a/test/it/group-rule-operations.ts
+++ b/test/it/group-rule-operations.ts
@@ -39,65 +39,92 @@ describe('Group-Rule API tests', () => {
     const createdUser = await client.createUser(newUser, queryParameters);
     const createdGroup = await client.createGroup(newGroup);
 
-    // 2. Create a group rule and verify rule executes
-    const rule = {
-      type: 'group_rule',
-      name: `node-sdk: ${faker.random.word().substring(0, 49)}`,
-      conditions: {
-        people: {
-          users: {
-            exclude: []
+    // 2. Create group rules
+    const rules = [];
+    const namePrefixes = [
+      'RULE_AB',
+      'RULE_XY'
+    ];
+    for (const prefix of namePrefixes) {
+      for (let i = 0 ; i < 2 ; i++) {
+        const rule = {
+          type: 'group_rule',
+          name: `node-sdk: ${prefix} ${i} ${faker.random.word().substring(0, 49)}`,
+          conditions: {
+            people: {
+              users: {
+                exclude: []
+              },
+              groups: {
+                exclude: []
+              }
+            },
+            expression: {
+              value: `user.lastName=="${createdUser.profile.lastName}"`,
+              type: 'urn:okta:expression:1.0'
+            }
           },
-          groups: {
-            exclude: []
+          actions: {
+            assignUserToGroups: {
+              groupIds: [
+                createdGroup.id
+              ]
+            }
           }
-        },
-        expression: {
-          value: `user.lastName=="${createdUser.profile.lastName}"`,
-          type: 'urn:okta:expression:1.0'
-        }
-      },
-      actions: {
-        assignUserToGroups: {
-          groupIds: [
-            createdGroup.id
-          ]
-        }
+        };
+        const createdRule = await client.createGroupRule(rule);
+        rules.push(createdRule);
       }
-    };
+    }
+    const firstRule = rules[0];
 
-    const createdRule = await client.createGroupRule(rule);
-    await client.activateGroupRule(createdRule.id);
+    // Activate first rule
+    await client.activateGroupRule(firstRule.id);
 
-    // We wait for 30 seconds for the rule to activate i.e. userInGroup = true
-    let userInGroup = await utils.waitTillUserInGroup(client, createdUser, createdGroup, true);
-    expect(userInGroup).to.equal(true);
-
-    // 3. List group rules
+    // 3a. List group rules
     let foundRule = false;
     await (await client.listGroupRules()).each(rule => {
-      if (rule.id === createdRule.id) {
+      if (rule.id === firstRule.id) {
         foundRule = true;
         return false;
       }
     });
     expect(foundRule).to.equal(true);
 
-    // 4. Deactivate the rule and update it
-    await client.deactivateGroupRule(createdRule.id);
+    // 3b. Search group rules with pagination
+    const filtered = new Set();
+    await (await client.listGroupRules({
+      search: 'RULE_AB',
+      limit: 1
+    })).each(rule => {
+      expect(filtered.has(rule.name)).to.be.false;
+      filtered.add(rule.name);
+      expect(rule.name.indexOf('RULE_AB')).to.not.equal(-1);
+    });
+    expect(filtered.size).to.equal(2);
 
-    createdRule.name = faker.random.word();
-    createdRule.conditions.expression.value = 'user.lastName=="incorrect"';
-    const updatedRule = await client.updateGroupRule(createdRule.id, createdRule);
+    // 4. Verify first rule executes
+    // We wait for 30 seconds for the rule to activate i.e. userInGroup = true
+    let userInGroup = await utils.waitTillUserInGroup(client, createdUser, createdGroup, true);
+    expect(userInGroup).to.equal(true);
+
+    // 4. Deactivate the rule and update it
+    await client.deactivateGroupRule(firstRule.id);
+
+    firstRule.name = faker.random.word();
+    firstRule.conditions.expression.value = 'user.lastName=="incorrect"';
+    const updatedRule = await client.updateGroupRule(firstRule.id, firstRule);
     await client.activateGroupRule(updatedRule.id);
 
     // Triggering the updated rule will remove the user from group i.e. userInGroup = false
     userInGroup = await utils.waitTillUserInGroup(client, createdUser, createdGroup, false);
     expect(userInGroup).to.equal(false);
 
-    // 5. Delete the group, user and group rule
+    // 5. Delete the group, user and group rules
     await client.deactivateGroupRule(updatedRule.id);
-    await client.deleteGroupRule(updatedRule.id);
+    for (const rule of rules) {
+      await client.deleteGroupRule(rule.id);
+    }
     await utils.cleanup(client, createdUser, createdGroup);
   });
 });

--- a/test/it/group-search.ts
+++ b/test/it/group-search.ts
@@ -78,7 +78,7 @@ describe('Group API tests', () => {
     await utils.cleanup(client, null, createdGroups);
   });
 
-  // TODO: OKTA-512396 - incompatibility in v2 and v3 specs
+  // TODO: OKTA-515269 - incompatibility in v2 and v3 specs
   xit('should filter with search and paginate results', async () => {
     // 1. Create new groups
     const createdGroups = await createTestGroups();

--- a/test/it/group-search.ts
+++ b/test/it/group-search.ts
@@ -45,7 +45,7 @@ describe('Group API tests', () => {
     const createdGroups = await createTestGroups();
 
     // 2. List with pagination
-    let listIds = new Set();
+    const listIds = new Set();
     const collection = await client.listGroups({ limit: 2 });
     await collection.each(async group => {
       expect(group).to.be.an.instanceof(okta.v3.Group);
@@ -64,9 +64,9 @@ describe('Group API tests', () => {
     const createdGroups = await createTestGroups();
 
     // 2. Search groups by name
-    const q = `node-sdk: Search test Group GROUP_AB`;
+    const q = 'node-sdk: Search test Group GROUP_AB';
     const collection = await client.listGroups({ q });
-    let filtered = new Set();
+    const filtered = new Set();
     await collection.each(async group => {
       expect(group).to.be.an.instanceof(okta.v3.Group);
       expect(group.profile.name).to.match(new RegExp(q));
@@ -84,7 +84,7 @@ describe('Group API tests', () => {
     const createdGroups = await createTestGroups();
 
     // 2. Filter groups with `search` and paginate results
-    let filtered = new Set();
+    const filtered = new Set();
     const q = 'node-sdk: Search test Group GROUP_XY';
     const collection = await client.listGroups({
       search: `type eq "OKTA_GROUP" AND profile.name sw "${q}"`,

--- a/test/it/group-search.ts
+++ b/test/it/group-search.ts
@@ -78,8 +78,8 @@ describe('Group API tests', () => {
     await utils.cleanup(client, null, createdGroups);
   });
 
-  // TODO: bug with excess `queryParams.filter` !!!
-  it('should filter with search and paginate results', async () => {
+  // TODO: OKTA-512396 - incompatibility in v2 and v3 specs
+  xit('should filter with search and paginate results', async () => {
     // 1. Create new groups
     const createdGroups = await createTestGroups();
 

--- a/test/it/group-search.ts
+++ b/test/it/group-search.ts
@@ -16,7 +16,71 @@ const client = new okta.Client({
   requestExecutor: new okta.DefaultRequestExecutor()
 });
 
+const namePrefixes = [
+  'GROUP_AB',
+  'GROUP_XY'
+];
+
+const createTestGroups = async () => {
+  const createdGroups = [];
+  for (const prefix of namePrefixes) {
+    for (let i = 0 ; i < 2 ; i++) {
+      const groupName = `node-sdk: Search test Group ${prefix} ${i} ${faker.random.word()}`.substring(0, 49);
+      const newGroup = {
+        profile: {
+          name: groupName
+        },
+      };
+      await utils.cleanup(client, null, newGroup);
+      const createdGroup = await client.createGroup(newGroup as okta.v3.Group);
+      utils.validateGroup(createdGroup, newGroup);
+      createdGroups.push(createdGroup);
+    }
+  }
+  return createdGroups;
+};
+
 describe('Group API tests', () => {
+  // TODO: OKTA-512396 - Filter works only as "starts with". Pagination does not work with filter
+  it('should search for groups by name', async () => {
+    // 1. Create new groups
+    const createdGroups = await createTestGroups();
+
+    // 2. Search groups by name
+    for (const prefix of namePrefixes) {
+      const q = `node-sdk: Search test Group ${prefix}`;
+      const collection = await client.listGroups({ q });
+      let filtered = new Set();
+      await collection.each(async group => {
+        expect(group).to.be.an.instanceof(okta.v3.Group);
+        expect(group.profile.name).to.match(new RegExp(q));
+        filtered.add(group.profile.name);
+      });
+      expect(filtered.size).to.equal(2);
+    }
+
+    // 3. Delete groups
+    await utils.cleanup(client, null, createdGroups);
+  });
+
+  it('should paginate results', async () => {
+    // 1. Create new groups
+    const createdGroups = await createTestGroups();
+
+    // 2. List with pagination
+    let listIds = new Set();
+    const collection = await client.listGroups({ limit: 2 });
+    await collection.each(async group => {
+      expect(group).to.be.an.instanceof(okta.v3.Group);
+      expect(listIds.has(group.id)).to.be.false;
+      listIds.add(group.id);
+    });
+    expect(listIds.size).to.be.greaterThanOrEqual(4);
+
+    // 3. Delete groups
+    await utils.cleanup(client, null, createdGroups);
+  });
+
   it('should search for the given group', async () => {
     // 1. Create a new group
     const groupName = `node-sdk: Search test Group ${faker.random.word()}`.substring(0, 49);

--- a/test/it/group-search.ts
+++ b/test/it/group-search.ts
@@ -16,12 +16,11 @@ const client = new okta.Client({
   requestExecutor: new okta.DefaultRequestExecutor()
 });
 
-const namePrefixes = [
-  'GROUP_AB',
-  'GROUP_XY'
-];
-
 const createTestGroups = async () => {
+  const namePrefixes = [
+    'GROUP_AB',
+    'GROUP_XY'
+  ];
   const createdGroups = [];
   for (const prefix of namePrefixes) {
     for (let i = 0 ; i < 2 ; i++) {
@@ -41,29 +40,7 @@ const createTestGroups = async () => {
 };
 
 describe('Group API tests', () => {
-  // TODO: OKTA-512396 - Filter works only as "starts with". Pagination does not work with filter
-  it('should search for groups by name', async () => {
-    // 1. Create new groups
-    const createdGroups = await createTestGroups();
-
-    // 2. Search groups by name
-    for (const prefix of namePrefixes) {
-      const q = `node-sdk: Search test Group ${prefix}`;
-      const collection = await client.listGroups({ q });
-      let filtered = new Set();
-      await collection.each(async group => {
-        expect(group).to.be.an.instanceof(okta.v3.Group);
-        expect(group.profile.name).to.match(new RegExp(q));
-        filtered.add(group.profile.name);
-      });
-      expect(filtered.size).to.equal(2);
-    }
-
-    // 3. Delete groups
-    await utils.cleanup(client, null, createdGroups);
-  });
-
-  it('should paginate results', async () => {
+  xit('should paginate results', async () => {
     // 1. Create new groups
     const createdGroups = await createTestGroups();
 
@@ -81,7 +58,48 @@ describe('Group API tests', () => {
     await utils.cleanup(client, null, createdGroups);
   });
 
-  it('should search for the given group', async () => {
+  xit('should search by name with q', async () => {
+    // 1. Create new groups
+    const createdGroups = await createTestGroups();
+
+    // 2. Search groups by name
+    const q = `node-sdk: Search test Group GROUP_AB`;
+    const collection = await client.listGroups({ q });
+    let filtered = new Set();
+    await collection.each(async group => {
+      expect(group).to.be.an.instanceof(okta.v3.Group);
+      expect(group.profile.name).to.match(new RegExp(q));
+      filtered.add(group.profile.name);
+    });
+    expect(filtered.size).to.equal(2);
+
+    // 3. Delete groups
+    await utils.cleanup(client, null, createdGroups);
+  });
+
+  // TODO: bug with excess `queryParams.filter` !!!
+  it('should filter with search and paginate results', async () => {
+    // 1. Create new groups
+    const createdGroups = await createTestGroups();
+
+    // 2. Filter groups with `search` and paginate results
+    let filtered = new Set();
+    const q = 'node-sdk: Search test Group GROUP_XY';
+    const collection = await client.listGroups({
+      search: `type eq "OKTA_GROUP" AND profile.name sw "${q}"`,
+      limit: 1
+    });
+    await collection.each(async group => {
+      expect(group).to.be.an.instanceof(okta.v3.Group);
+      filtered.add(group.profile.name);
+    });
+    expect(filtered.size).to.equal(2);
+
+    // 3. Delete groups
+    await utils.cleanup(client, null, createdGroups);
+  });
+
+  xit('should search for the given group', async () => {
     // 1. Create a new group
     const groupName = `node-sdk: Search test Group ${faker.random.word()}`.substring(0, 49);
     const newGroup = {

--- a/test/it/group-search.ts
+++ b/test/it/group-search.ts
@@ -40,7 +40,7 @@ const createTestGroups = async () => {
 };
 
 describe('Group API tests', () => {
-  xit('should paginate results', async () => {
+  it('should paginate results', async () => {
     // 1. Create new groups
     const createdGroups = await createTestGroups();
 
@@ -58,7 +58,7 @@ describe('Group API tests', () => {
     await utils.cleanup(client, null, createdGroups);
   });
 
-  xit('should search by name with q', async () => {
+  it('should search by name with q', async () => {
     // 1. Create new groups
     const createdGroups = await createTestGroups();
 
@@ -99,7 +99,7 @@ describe('Group API tests', () => {
     await utils.cleanup(client, null, createdGroups);
   });
 
-  xit('should search for the given group', async () => {
+  it('should search for the given group', async () => {
     // 1. Create a new group
     const groupName = `node-sdk: Search test Group ${faker.random.word()}`.substring(0, 49);
     const newGroup = {

--- a/test/it/group-search.ts
+++ b/test/it/group-search.ts
@@ -58,6 +58,7 @@ describe('Group API tests', () => {
     await utils.cleanup(client, null, createdGroups);
   });
 
+  // Pagination does not work with q
   it('should search by name with q', async () => {
     // 1. Create new groups
     const createdGroups = await createTestGroups();

--- a/test/it/idp-crud.ts
+++ b/test/it/idp-crud.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { spy } from 'sinon';
 import {
   Client,
   Collection,
@@ -52,11 +53,16 @@ describe('Idp Crud API', () => {
 
     it('should return a collection with pagination', async () => {
       const listIds = new Set();
-      await (await client.listIdentityProviders({ limit: 1 })).each(idp => {
+      const collection = await client.listIdentityProviders({
+        limit: 2
+      });
+      const pageSpy = spy(collection, 'getNextPage');
+      await collection.each(idp => {
         expect(listIds.has(idp.id)).to.be.false;
         listIds.add(idp.id);
       });
       expect(listIds.size).to.be.greaterThanOrEqual(4);
+      expect(pageSpy.getCalls().length).to.be.greaterThanOrEqual(2);
     });
 
     // TODO: OKTA-515269 - Filter by type does not work correctly

--- a/test/it/idp-crud.ts
+++ b/test/it/idp-crud.ts
@@ -59,7 +59,7 @@ describe('Idp Crud API', () => {
       expect(listIds.size).to.be.greaterThanOrEqual(4);
     });
 
-    // TODO: OKTA-512396 - Filter by type does not work correctly
+    // TODO: OKTA-515269 - Filter by type does not work correctly
     xit('should filter idps by type', async () => {
       await (await client.listIdentityProviders({ type: 'FACEBOOK' })).each(idp => {
         expect(idp.type).to.equal('FACEBOOK');
@@ -72,7 +72,7 @@ describe('Idp Crud API', () => {
       });
     });
 
-    // TODO: OKTA-512396 - Filter with q does not work correctly
+    // TODO: OKTA-515269 - Filter with q does not work correctly
     xit('should search idps with q', async () => {
       await (await client.listIdentityProviders({ q: 'node-sdk: Facebook' })).each(idp => {
         expect(idp.type).to.equal('FACEBOOK');

--- a/test/it/idp-crud.ts
+++ b/test/it/idp-crud.ts
@@ -51,7 +51,7 @@ describe('Idp Crud API', () => {
     });
 
     it('should return a collection with pagination', async () => {
-      let listIds = new Set();
+      const listIds = new Set();
       await (await client.listIdentityProviders({ limit: 1 })).each(idp => {
         expect(listIds.has(idp.id)).to.be.false;
         listIds.add(idp.id);

--- a/test/it/idp-crud.ts
+++ b/test/it/idp-crud.ts
@@ -59,8 +59,8 @@ describe('Idp Crud API', () => {
       expect(listIds.size).to.be.greaterThanOrEqual(4);
     });
 
-    // TODO: OKTA-512396 - Filter does not work correctly
-    xit('should return a collection of idp by type', async () => {
+    // TODO: OKTA-512396 - Filter by type does not work correctly
+    xit('should filter idps by type', async () => {
       await (await client.listIdentityProviders({ type: 'FACEBOOK' })).each(idp => {
         expect(idp.type).to.equal('FACEBOOK');
       });
@@ -72,14 +72,15 @@ describe('Idp Crud API', () => {
       });
     });
 
-    xit('should return a collection of idp by q', async () => {
-      await (await client.listIdentityProviders({ q: 'Facebook' })).each(idp => {
+    // TODO: OKTA-512396 - Filter with q does not work correctly
+    xit('should search idps with q', async () => {
+      await (await client.listIdentityProviders({ q: 'node-sdk: Facebook' })).each(idp => {
         expect(idp.type).to.equal('FACEBOOK');
       });
-      await (await client.listIdentityProviders({ q: 'Google' })).each(idp => {
+      await (await client.listIdentityProviders({ q: 'node-sdk: Google' })).each(idp => {
         expect(idp.type).to.equal('GOOGLE');
       });
-      await (await client.listIdentityProviders({ q: 'OIDC' })).each(idp => {
+      await (await client.listIdentityProviders({ q: 'node-sdk: OIDC' })).each(idp => {
         expect(idp.type).to.equal('OIDC');
       });
     });

--- a/test/it/idp-crud.ts
+++ b/test/it/idp-crud.ts
@@ -50,7 +50,16 @@ describe('Idp Crud API', () => {
       });
     });
 
-    // TODO: OKTA-512396 - Filter and pagination does not work correctly
+    it('should return a collection with pagination', async () => {
+      let listIds = new Set();
+      await (await client.listIdentityProviders({ limit: 1 })).each(idp => {
+        expect(listIds.has(idp.id)).to.be.false;
+        listIds.add(idp.id);
+      });
+      expect(listIds.size).to.be.greaterThanOrEqual(4);
+    });
+
+    // TODO: OKTA-512396 - Filter does not work correctly
     xit('should return a collection of idp by type', async () => {
       await (await client.listIdentityProviders({ type: 'FACEBOOK' })).each(idp => {
         expect(idp.type).to.equal('FACEBOOK');
@@ -58,12 +67,11 @@ describe('Idp Crud API', () => {
       await (await client.listIdentityProviders({ type: 'GOOGLE' })).each(idp => {
         expect(idp.type).to.equal('GOOGLE');
       });
-      await (await client.listIdentityProviders({ type: 'OIDC', limit: 1 })).each(idp => {
+      await (await client.listIdentityProviders({ type: 'OIDC' })).each(idp => {
         expect(idp.type).to.equal('OIDC');
       });
     });
 
-    // TODO: OKTA-512396 - Filter and pagination does not work correctly
     xit('should return a collection of idp by q', async () => {
       await (await client.listIdentityProviders({ q: 'Facebook' })).each(idp => {
         expect(idp.type).to.equal('FACEBOOK');
@@ -71,7 +79,7 @@ describe('Idp Crud API', () => {
       await (await client.listIdentityProviders({ q: 'Google' })).each(idp => {
         expect(idp.type).to.equal('GOOGLE');
       });
-      await (await client.listIdentityProviders({ q: 'OIDC', limit: 1 })).each(idp => {
+      await (await client.listIdentityProviders({ q: 'OIDC' })).each(idp => {
         expect(idp.type).to.equal('OIDC');
       });
     });

--- a/test/it/mocks/generic-oidc-idp.js
+++ b/test/it/mocks/generic-oidc-idp.js
@@ -2,7 +2,7 @@ const faker = require('@faker-js/faker');
 
 module.exports = () => ({
   type: 'OIDC',
-  name: `node-sdk: ${faker.random.word().substring(0, 49)}`,
+  name: `node-sdk: OIDC ${faker.random.word().substring(0, 49)}`,
   issuerMode: 'ORG_URL',
   protocol: {
     algorithms: {

--- a/test/it/network-zone.ts
+++ b/test/it/network-zone.ts
@@ -2,7 +2,9 @@ import { expect } from 'chai';
 import {
   Client,
   DefaultRequestExecutor,
-  v3} from '@okta/okta-sdk-nodejs';
+  v3
+} from '@okta/okta-sdk-nodejs';
+import faker = require('@faker-js/faker');
 
 let orgUrl = process.env.OKTA_CLIENT_ORGURL;
 if (process.env.OKTA_USE_MOCK) {
@@ -16,37 +18,59 @@ const client = new Client({
   requestExecutor: new DefaultRequestExecutor()
 });
 
-describe('Network Zone API', () => {
+const buildBlockedNetworkZone = (): v3.NetworkZone => {
+  return {
+    type: 'IP',
+    id: null,
+    name: 'newBlockedNetworkZone',
+    status: 'ACTIVE',
+    created: null,
+    lastUpdated: null,
+    gateways: [
+      {
+        type: 'RANGE',
+        value: '123.123.123.123-123.123.123.123'
+      }
+    ],
+    proxies: null
+  };
+};
+
+const buildNetworkZone = (): v3.NetworkZone => {
+  return {
+    type: 'IP',
+    id: null,
+    name: 'newNetworkZone',
+    status: 'ACTIVE',
+    created: null,
+    lastUpdated: null,
+    gateways: [
+      {
+        type: 'CIDR',
+        value: '1.2.3.4/24'
+      },
+      {
+        type: 'CIDR',
+        value: '2.3.4.5/24'
+      }
+    ],
+    proxies: [
+      {
+        type: 'CIDR',
+        value: '2.2.3.4/24'
+      },
+      {
+        type: 'CIDR',
+        value: '3.3.4.5/24'
+      }
+    ]
+  };
+};
+
+describe('Network Zone CRUD', () => {
   let networkZone: v3.NetworkZone;
   beforeEach(async () => {
-    networkZone = await client.createNetworkZone({
-      type: 'IP',
-      id: null,
-      name: 'newNetworkZone',
-      status: 'ACTIVE',
-      created: null,
-      lastUpdated: null,
-      gateways: [
-        {
-          type: 'CIDR',
-          value: '1.2.3.4/24'
-        },
-        {
-          type: 'CIDR',
-          value: '2.3.4.5/24'
-        }
-      ],
-      proxies: [
-        {
-          type: 'CIDR',
-          value: '2.2.3.4/24'
-        },
-        {
-          type: 'CIDR',
-          value: '3.3.4.5/24'
-        }
-      ]
-    });
+    networkZone = await client.createNetworkZone(buildNetworkZone());
   });
 
   afterEach(async () => {
@@ -77,5 +101,57 @@ describe('Network Zone API', () => {
     expect(response.status).to.equal('ACTIVE');
     updatedNetworkZone = await client.getNetworkZone(networkZone.id);
     expect(updatedNetworkZone.status).to.equal('ACTIVE');
+  });
+});
+
+describe('List Network Zones', () => {
+  let networkZones: Array<v3.NetworkZone>;
+  before(async () => {
+    networkZones = [];
+    const namePrefixes = [
+      'NZ_POLICY',
+      'NZ_BLOCKLIST'
+    ];
+    for (const prefix of namePrefixes) {
+      for (let i = 0 ; i < 2 ; i++) {
+        const networkZone = await client.createNetworkZone({
+          ...(prefix === 'NZ_POLICY' ? buildNetworkZone() : buildBlockedNetworkZone()),
+          name: `node-sdk: ${prefix} ${i} ${faker.random.word()}`.substring(0, 49),
+          usage: prefix === 'NZ_POLICY' ? 'POLICY' : 'BLOCKLIST'
+        });
+        networkZones.push(networkZone);
+      }
+    }
+  });
+
+  after(async () => {
+    for (const networkZone of networkZones) {
+      await client.deleteNetworkZone(networkZone.id);
+    }
+  });
+
+  it('should paginate results', async () => {
+    const filtered = new Set();
+    await (await client.listNetworkZones({ limit: 3 })).each(nz => {
+      expect(nz).to.be.an.instanceof(v3.NetworkZone);
+      expect(filtered.has(nz.name)).to.be.false;
+      filtered.add(nz.name);
+    });
+    expect(filtered.size).to.be.greaterThanOrEqual(4);
+  });
+
+  // Pagination does not work with filter
+  it('should filter with filter', async () => {
+    const queryParameters = {
+      filter: 'usage eq "POLICY"'
+    };
+    const filtered = new Set();
+    await (await client.listNetworkZones(queryParameters)).each(nz => {
+      expect(nz).to.be.an.instanceof(v3.NetworkZone);
+      expect(filtered.has(nz.name)).to.be.false;
+      filtered.add(nz.name);
+      expect(nz.name.indexOf('node-sdk: NZ_BLOCKLIST')).to.equal(-1);
+    });
+    expect(filtered.size).to.be.greaterThanOrEqual(2);
   });
 });

--- a/test/it/network-zone.ts
+++ b/test/it/network-zone.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { spy } from 'sinon';
 import {
   Client,
   DefaultRequestExecutor,
@@ -132,11 +133,14 @@ describe('List Network Zones', () => {
 
   it('should paginate results', async () => {
     const filtered = new Set();
-    await (await client.listNetworkZones({ limit: 3 })).each(nz => {
+    const collection = await client.listNetworkZones({ limit: 3 });
+    const pageSpy = spy(collection, 'getNextPage');
+    await collection.each(nz => {
       expect(nz).to.be.an.instanceof(v3.NetworkZone);
       expect(filtered.has(nz.name)).to.be.false;
       filtered.add(nz.name);
     });
+    expect(pageSpy.getCalls().length).to.be.greaterThanOrEqual(2);
     expect(filtered.size).to.be.greaterThanOrEqual(4);
   });
 

--- a/test/it/trusted-origin.ts
+++ b/test/it/trusted-origin.ts
@@ -119,7 +119,7 @@ describe('Trusted Origin API', () => {
 
     it('should filter with filter', async () => {
       const queryParameters = {
-        filter: `type eq "REDIRECT"`,
+        filter: 'type eq "REDIRECT"',
         limit: 2
       };
       const filtered = new Set();

--- a/test/it/trusted-origin.ts
+++ b/test/it/trusted-origin.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { spy } from 'sinon';
 import {
   v3,
   Client,
@@ -95,11 +96,14 @@ describe('Trusted Origin API', () => {
 
     it('should paginate results', async () => {
       const filtered = new Set();
-      await (await client.listOrigins({ limit: 3 })).each(origin => {
+      const collection = await client.listOrigins({ limit: 3 });
+      const pageSpy = spy(collection, 'getNextPage');
+      await collection.each(origin => {
         expect(origin).to.be.an.instanceof(v3.TrustedOrigin);
         expect(filtered.has(origin.name)).to.be.false;
         filtered.add(origin.name);
       });
+      expect(pageSpy.getCalls().length).to.be.greaterThanOrEqual(2);
       expect(filtered.size).to.be.greaterThanOrEqual(4);
     });
 

--- a/test/it/user-list-enrolled-factors.ts
+++ b/test/it/user-list-enrolled-factors.ts
@@ -2,11 +2,8 @@ import utils = require('../utils');
 import {
   Client,
   DefaultRequestExecutor,
-  SecurityQuestionUserFactor,
-  SmsUserFactor,
   Policy,
-  v3,
-  CallUserFactor
+  v3
 } from '@okta/okta-sdk-nodejs';
 import { expect } from 'chai';
 let orgUrl = process.env.OKTA_CLIENT_ORGURL;

--- a/test/it/user-schema.ts
+++ b/test/it/user-schema.ts
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import {
   Client,
   DefaultRequestExecutor,
-  UserType,
   v3,
 } from '@okta/okta-sdk-nodejs';
 

--- a/test/it/user-type-api.ts
+++ b/test/it/user-type-api.ts
@@ -1,7 +1,7 @@
 import { ServerConfiguration } from './../../src/generated/servers';
 import  { createConfiguration } from './../../src/generated/configuration';
 import { expect } from 'chai';
-import { Client, UserType, v3} from '@okta/okta-sdk-nodejs';
+import { Client, v3} from '@okta/okta-sdk-nodejs';
 
 
 describe('User Type API', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,7 +31,7 @@
   resolved "https://registry.yarnpkg.com/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz#b789a362e055b0340d04712eafe7027ddc1ac267"
   integrity sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==
 
-"@apidevtools/swagger-parser@^10.0.1":
+"@apidevtools/swagger-parser@^10.0.1", "@apidevtools/swagger-parser@^10.1.0":
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/@apidevtools/swagger-parser/-/swagger-parser-10.1.0.tgz#a987d71e5be61feb623203be0c96e5985b192ab6"
   integrity sha512-9Kt7EuS/7WbMAUv2gSziqjvxwDbFSg3Xeyfuj5laUODX8o/k/CpsAKiQ8W7/R88eXFTMbJYg6+7uAmOWNKmwnw==


### PR DESCRIPTION
Internal ref: OKTA-512396

- Added filter and pagination integration tests
- Added `yarn validate:v2-v3` to catch v2 vs v3 specs incompatibility. 

Found issues:
- `listIdentityProviders` - `type` and `q` does not work (server issue)
- `listUsers` - using  `q` produces error (query params incompatibility in v2 vs v3 specs)
- `listGroups` - using  `search` and `limit` produces error (query params incompatibility in v2 vs v3 specs)
- `listApplications` - `includeNonDeleted` has no effect (spec issue)
- `listAuthorizationServers` - `limit` should be number, not string (spec issue)
- `listOrigins` - pagination with `q` works incorrectly, `q` is replaced with `filter` in `next` link (server issue)
- `listOAuth2Scopes` - `filter`, `limit`, `after` does not work and not documented (spec issue?)

(follow-up OKTA-515269)

