### PR TITLE
fix: Encode special characters in path parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Okta Node SDK Changelog
 
+# 7.0.1
+
+### Bug Fixes
+
+- [#395](https://github.com/okta/okta-sdk-nodejs/pull/395) fix: Encode special characters in path parameters
+
 # 7.0.0
 
 ### Other

--- a/src/generated/servers.js
+++ b/src/generated/servers.js
@@ -45,8 +45,13 @@ class ServerConfiguration {
     }
     return replacedUrl;
   }
+  _encodeParam(val) {
+    return val !== undefined ? encodeURIComponent(val) : undefined;
+  }
   getEndpointUrl(endpoint, vars) {
-    const endpointWithVars = endpoint.replace(/{(\w+)}/g, (match, key) => vars?.[key] || match);
+    const endpointWithVars = endpoint.replace(/{(\w+)}/g, (match, key) =>
+      this._encodeParam(vars?.[key]) || match
+    );
     return this.getUrl() + endpointWithVars;
   }
   getAffectedResources(path, vars) {
@@ -54,7 +59,9 @@ class ServerConfiguration {
     let pl = path.length;
     while (pl--) {
       if (path[pl] === '}') {
-        const resourcePath = path.slice(0, pl + 1).replace(/{(\w+)}/g, (match, key) => vars?.[key] || match);
+        const resourcePath = path.slice(0, pl + 1).replace(/{(\w+)}/g, (match, key) =>
+          this._encodeParam(vars?.[key]) || match
+        );
         resources.push(this.getUrl() + resourcePath);
       }
     }

--- a/templates/openapi-generator/http/servers.mustache
+++ b/templates/openapi-generator/http/servers.mustache
@@ -26,6 +26,10 @@ export class ServerConfiguration<T extends { [key: string]: string }> implements
         return this.variableConfiguration
     }
 
+    private _encodeParam(val: string) {
+        return val !== undefined ? encodeURIComponent(val) : undefined;
+    }
+
     private getUrl(): string {
         let replacedUrl = this.url;
         for (const key in this.variableConfiguration) {
@@ -36,7 +40,9 @@ export class ServerConfiguration<T extends { [key: string]: string }> implements
     }
 
     private getEndpointUrl(endpoint: string, vars?: Partial<T>): string {
-        const endpointWithVars = endpoint.replace(/{(\w+)}/g, (match, key) => vars?.[key] || match);
+        const endpointWithVars = endpoint.replace(/{(\w+)}/g, (match, key) =>
+            this._encodeParam(vars?.[key]) || match
+        );
         return this.getUrl() + endpointWithVars;
     }
 
@@ -45,7 +51,9 @@ export class ServerConfiguration<T extends { [key: string]: string }> implements
         let pl = path.length;
         while (pl--) {
         if (path[pl] === '}') {
-            const resourcePath = path.slice(0, pl + 1).replace(/{(\w+)}/g, (match, key) => vars?.[key] || match);
+            const resourcePath = path.slice(0, pl + 1).replace(/{(\w+)}/g, (match, key) =>
+                this._encodeParam(vars?.[key]) || match
+            );
             resources.push(this.getUrl() + resourcePath);
         }
         }

--- a/test/jest/servers.test.js
+++ b/test/jest/servers.test.js
@@ -1,0 +1,51 @@
+const { ServerConfiguration } = require('../../src/generated/servers');
+
+describe('ServerConfiguration', () => {
+  describe('getEndpointUrl', () => {
+    it('encodes path parameters', () => {
+      const server = new ServerConfiguration('https://fakey.local');
+      const path = '/api/v1/users/{userId}';
+      const vars = {
+        userId: 'test#user@okta.com',
+      };
+      const endpoint = server.getEndpointUrl(path, vars);
+      expect(endpoint).toBe('https://fakey.local/api/v1/users/test%23user%40okta.com');
+    });
+    it('if path parameter value not provided, leave as is', () => {
+      const server = new ServerConfiguration('https://fakey.local');
+      const path = '/api/v1/users/{userId}';
+      const vars = {
+      };
+      const endpoint = server.getEndpointUrl(path, vars);
+      expect(endpoint).toBe('https://fakey.local/api/v1/users/{userId}');
+    });
+  });
+
+  describe('getUrl', () => {
+    it('does not encode parameters in base URL', () => {
+      const url = 'https://{domain}';
+      const vars = {
+        domain: 'my.domain.com:8080',
+      };
+      const server = new ServerConfiguration(url, vars);
+      const baseUrl = server.getUrl();
+      expect(baseUrl).toBe('https://my.domain.com:8080');
+    });
+  });
+
+  describe('getAffectedResources', () => {
+    it('encodes path parameters', () => {
+      const server = new ServerConfiguration('https://fakey.local');
+      const path = '/api/v1/users/{userId}/grants/{grantId}';
+      const vars = {
+        userId: 'test#user@okta.com',
+        grantId: '123?'
+      };
+      const affectedResources = server.getAffectedResources(path, vars);
+      expect(affectedResources).toEqual([
+        'https://fakey.local/api/v1/users/test%23user%40okta.com/grants/123%3F',
+        'https://fakey.local/api/v1/users/test%23user%40okta.com',
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-sdk-nodejs/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?

Special characters in path parameters are not encoded.
Example:
```js
await client.userApi.getUser({
  userId: 'test#user@okta.com'
});
```
Request is sent to `https://mydomain.com/api/v1/users/test#user@okta.com`

Issue Number: [OKTA-618059](https://oktainc.atlassian.net/browse/OKTA-618059), [OKTA-609249](https://oktainc.atlassian.net/browse/OKTA-609249)


## What is the new behavior?

Request is sent to `https://mydomain.com/api/v1/users/test%23user%40okta.com`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

