### PR TITLE
chore: add the manager email to the UserProfile type definition

### DIFF
--- a/src/types/generated/models/UserProfile.d.ts
+++ b/src/types/generated/models/UserProfile.d.ts
@@ -43,6 +43,7 @@ export declare class UserProfile {
   'login'?: string;
   'manager'?: string;
   'managerId'?: string;
+  'manageremail'?: string;
   'middleName'?: string;
   'mobilePhone'?: string;
   'nickName'?: string;


### PR DESCRIPTION
## Description

I did notice that the type definition for the UserProfile is not accurate, as when checking my response I catch an additional field. That field is the `manageremail`.

So I wanted just to improve the type, so that other users may expect it as well.

![Screenshot 2024-04-09 at 18 51 12](https://github.com/okta/okta-sdk-nodejs/assets/31168388/c107bd33-28fd-465f-848e-8b892da3edec)
