### PR TITLE
fix: support esm named imports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,14 +17,13 @@ const { Collection } = require('./collection');
 const MemoryStore = require('./memory-store');
 const OktaApiError = require('./api-error');
 
+module.exports.Client = Client
+module.exports.RequestExecutor = RequestExecutor
+module.exports.DefaultRequestExecutor = DefaultRequestExecutor
+module.exports.Collection = Collection
+module.exports.MemoryStore = MemoryStore
+module.exports.OktaApiError = OktaApiError
 module.exports = Object.assign(
-  {}, {
-    Client,
-    RequestExecutor,
-    DefaultRequestExecutor,
-    Collection,
-    MemoryStore,
-    OktaApiError,
-  },
+  module.exports,
   require('./generated'),
 );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our [guidelines](/okta/okta-sdk-nodejs/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using named imports in ESM you see the error saying that module.exports:

```
import { Client } from '@okta/okta-sdk-nodejs';
         ^^^^^^
SyntaxError: Named export 'Client' not found. The requested module '@okta/okta-sdk-nodejs' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from '@okta/okta-sdk-nodejs';
const { Client } = pkg;
```

Issue Number: N/A


## What is the new behavior?
You can use named imports in ESM:

**index.js**
```js
import { Client } from '@okta/okta-sdk-nodejs'
console.log('Client using named import', Client)
```
```json
{
  "type": "module",
  "dependencies": {
    "@okta/okta-sdk-nodejs": "7.1.1"
  }
}
```

```bash
node ./index.js
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
As called out in [this typescript issue](https://github.com/microsoft/TypeScript/issues/54018):
> Node uses [cjs-module-lexer](https://github.com/nodejs/cjs-module-lexer) to syntactically analyze CommonJS modules without executing them in order to turn module.exports properties into named exports that can be imported as named (or namespace) imports by ES modules. However, syntactic analysis has its limitations, and not all module.exports properties get detected on all modules. (In practice, it’s common for this to be all-or-nothing, as with the typescript package in its current state: it has no named exports available.)

## Reviewers

