### PR TITLE
fix: upgrade lodash to 4.17.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "form-data": "^4.0.4",
     "https-proxy-agent": "^5.0.0",
     "js-yaml": "^4.1.0",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.23",
     "njwt": "^2.0.1",
     "node-fetch": "^2.6.7",
     "node-jose": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3189,10 +3189,15 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.17.15, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+lodash@^4.17.23:
+  version "4.17.23"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
+  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
 
 log-symbols@4.1.0, log-symbols@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
`lodash@^4.17.20` is vulnerable to prototype pollution via `_.unset` and `_.omit` functions (CVE). An attacker can pass crafted paths which cause Lodash to delete methods from global prototypes.

Issue Number: OKTA-1109092


## What is the new behavior?
Upgraded `lodash` from `^4.17.20` to `^4.17.23` which contains the security patch that sanitizes paths in `_.unset` and `_.omit` to block crafted prototype-polluting paths using `__proto__`, `constructor`, and `prototype` segments.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
- Only package.json and yarn.lock are changed.
- No API changes, no behavioral changes to the two lodash functions used in this SDK (`_.get` and `_.mergeWith`).
- Patch-level semver bump — fully backward compatible.
- Resolves the vulnerability reported by `npm audit` and GitHub Security Dependabot alerts.

## Reviewers

---