### PR TITLE
Add provider param to generateResetPasswordToken

### DIFF
--- a/oas-spec/management.yaml
+++ b/oas-spec/management.yaml
@@ -24782,6 +24782,12 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: provider
+          description: Specifies the authentication provider to use when converting a user to a federated user. Use `FEDERATION` to convert an Okta-credentialed user to a federated user. After conversion, the user can't directly sign in with a password and must authenticate through a trusted identity provider.
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/AuthenticationProviderType'
       responses:
         '200':
           description: Success

--- a/src/generated/apis/UserApi.js
+++ b/src/generated/apis/UserApi.js
@@ -569,8 +569,9 @@ class UserApiRequestFactory extends baseapi_1.BaseAPIRequestFactory {
      * @param userId An ID, login, or login shortname (as long as the shortname is unambiguous) of an existing Okta user
      * @param sendEmail
      * @param revokeSessions Revokes all user sessions, except for the current session, if set to &#x60;true&#x60;
+     * @param provider Specifies the authentication provider to use when converting a user to a federated user. Use &#x60;FEDERATION&#x60; to convert an Okta-credentialed user to a federated user. After conversion, the user can\&#39;t directly sign in with a password and must authenticate through a trusted identity provider.
      */
-  async generateResetPasswordToken(userId, sendEmail, revokeSessions, _options) {
+  async generateResetPasswordToken(userId, sendEmail, revokeSessions, provider, _options) {
     let _config = _options || this.configuration;
     // verify required parameter 'userId' is not null or undefined
     if (userId === null || userId === undefined) {
@@ -595,6 +596,10 @@ class UserApiRequestFactory extends baseapi_1.BaseAPIRequestFactory {
     // Query Params
     if (revokeSessions !== undefined) {
       requestContext.setQueryParam('revokeSessions', ObjectSerializer_1.ObjectSerializer.serialize(revokeSessions, 'boolean', ''));
+    }
+    // Query Params
+    if (provider !== undefined) {
+      requestContext.setQueryParam('provider', ObjectSerializer_1.ObjectSerializer.serialize(provider, 'AuthenticationProviderType', ''));
     }
     let authMethod;
     // Apply auth methods

--- a/src/generated/types/ObjectParamAPI.js
+++ b/src/generated/types/ObjectParamAPI.js
@@ -6367,7 +6367,7 @@ class ObjectUserApi {
       * @param param the request object
       */
     generateResetPasswordToken(param, options) {
-        return this.api.generateResetPasswordToken(param.userId, param.sendEmail, param.revokeSessions, options).toPromise();
+        return this.api.generateResetPasswordToken(param.userId, param.sendEmail, param.revokeSessions, param.provider, options).toPromise();
     }
     /**
       * Retrieves a linked identity provider (IdP) user by ID

--- a/src/generated/types/ObservableAPI.js
+++ b/src/generated/types/ObservableAPI.js
@@ -15800,9 +15800,10 @@ class ObservableUserApi {
       * @param userId An ID, login, or login shortname (as long as the shortname is unambiguous) of an existing Okta user
       * @param sendEmail
       * @param revokeSessions Revokes all user sessions, except for the current session, if set to &#x60;true&#x60;
+      * @param provider Specifies the authentication provider to use when converting a user to a federated user. Use &#x60;FEDERATION&#x60; to convert an Okta-credentialed user to a federated user. After conversion, the user can\&#39;t directly sign in with a password and must authenticate through a trusted identity provider.
       */
-  generateResetPasswordToken(userId, sendEmail, revokeSessions, _options) {
-    const requestContextPromise = this.requestFactory.generateResetPasswordToken(userId, sendEmail, revokeSessions, _options);
+  generateResetPasswordToken(userId, sendEmail, revokeSessions, provider, _options) {
+    const requestContextPromise = this.requestFactory.generateResetPasswordToken(userId, sendEmail, revokeSessions, provider, _options);
     // build promise chain
     let middlewarePreObservable = (0, rxjsStub_1.from)(requestContextPromise);
     for (let middleware of this.configuration.middleware) {

--- a/src/generated/types/PromiseAPI.js
+++ b/src/generated/types/PromiseAPI.js
@@ -7656,9 +7656,10 @@ class PromiseUserApi {
       * @param userId An ID, login, or login shortname (as long as the shortname is unambiguous) of an existing Okta user
       * @param sendEmail
       * @param revokeSessions Revokes all user sessions, except for the current session, if set to &#x60;true&#x60;
+      * @param provider Specifies the authentication provider to use when converting a user to a federated user. Use &#x60;FEDERATION&#x60; to convert an Okta-credentialed user to a federated user. After conversion, the user can\&#39;t directly sign in with a password and must authenticate through a trusted identity provider.
       */
-  generateResetPasswordToken(userId, sendEmail, revokeSessions, _options) {
-    const result = this.api.generateResetPasswordToken(userId, sendEmail, revokeSessions, _options);
+  generateResetPasswordToken(userId, sendEmail, revokeSessions, provider, _options) {
+    const result = this.api.generateResetPasswordToken(userId, sendEmail, revokeSessions, provider, _options);
     return result.toPromise();
   }
   /**

--- a/src/types/generated/apis/UserApi.d.ts
+++ b/src/types/generated/apis/UserApi.d.ts
@@ -15,6 +15,7 @@ import { BaseAPIRequestFactory } from './baseapi';
 import { Configuration } from '../configuration';
 import { RequestContext, ResponseContext } from '../http/http';
 import { AssignedAppLink } from '../models/AssignedAppLink';
+import { AuthenticationProviderType } from '../models/AuthenticationProviderType';
 import { ChangePasswordRequest } from '../models/ChangePasswordRequest';
 import { CreateUserRequest } from '../models/CreateUserRequest';
 import { ForgotPasswordResponse } from '../models/ForgotPasswordResponse';
@@ -140,8 +141,9 @@ export declare class UserApiRequestFactory extends BaseAPIRequestFactory {
      * @param userId An ID, login, or login shortname (as long as the shortname is unambiguous) of an existing Okta user
      * @param sendEmail
      * @param revokeSessions Revokes all user sessions, except for the current session, if set to &#x60;true&#x60;
+     * @param provider Specifies the authentication provider to use when converting a user to a federated user. Use &#x60;FEDERATION&#x60; to convert an Okta-credentialed user to a federated user. After conversion, the user can\&#39;t directly sign in with a password and must authenticate through a trusted identity provider.
      */
-  generateResetPasswordToken(userId: string, sendEmail: boolean, revokeSessions?: boolean, _options?: Configuration): Promise<RequestContext>;
+  generateResetPasswordToken(userId: string, sendEmail: boolean, revokeSessions?: boolean, provider?: AuthenticationProviderType, _options?: Configuration): Promise<RequestContext>;
   /**
      * Retrieves a linked identity provider (IdP) user by ID
      * Retrieve a user for IdP

--- a/src/types/generated/types/ObjectParamAPI.d.ts
+++ b/src/types/generated/types/ObjectParamAPI.d.ts
@@ -53,6 +53,7 @@ import { AssignedAppLink } from '../models/AssignedAppLink';
 import { AssociatedServerMediated } from '../models/AssociatedServerMediated';
 import { AttackProtectionAuthenticatorSettings } from '../models/AttackProtectionAuthenticatorSettings';
 import { AuthSettings } from '../models/AuthSettings';
+import { AuthenticationProviderType } from '../models/AuthenticationProviderType';
 import { AuthenticatorBase } from '../models/AuthenticatorBase';
 import { AuthenticatorEnrollment } from '../models/AuthenticatorEnrollment';
 import { AuthenticatorEnrollmentCreateRequest } from '../models/AuthenticatorEnrollmentCreateRequest';
@@ -14263,6 +14264,12 @@ export interface UserApiGenerateResetPasswordTokenRequest {
       * @memberof UserApigenerateResetPasswordToken
       */
     revokeSessions?: boolean;
+    /**
+      * Specifies the authentication provider to use when converting a user to a federated user. Use &#x60;FEDERATION&#x60; to convert an Okta-credentialed user to a federated user. After conversion, the user can\&#39;t directly sign in with a password and must authenticate through a trusted identity provider.
+      * @type AuthenticationProviderType
+      * @memberof UserApigenerateResetPasswordToken
+      */
+    provider?: AuthenticationProviderType;
 }
 export interface UserApiGetIdentityProviderApplicationUserRequest {
     /**

--- a/src/types/generated/types/ObservableAPI.d.ts
+++ b/src/types/generated/types/ObservableAPI.d.ts
@@ -54,6 +54,7 @@ import { AssignedAppLink } from '../models/AssignedAppLink';
 import { AssociatedServerMediated } from '../models/AssociatedServerMediated';
 import { AttackProtectionAuthenticatorSettings } from '../models/AttackProtectionAuthenticatorSettings';
 import { AuthSettings } from '../models/AuthSettings';
+import { AuthenticationProviderType } from '../models/AuthenticationProviderType';
 import { AuthenticatorBase } from '../models/AuthenticatorBase';
 import { AuthenticatorEnrollment } from '../models/AuthenticatorEnrollment';
 import { AuthenticatorEnrollmentCreateRequest } from '../models/AuthenticatorEnrollmentCreateRequest';
@@ -5852,8 +5853,9 @@ export declare class ObservableUserApi {
       * @param userId An ID, login, or login shortname (as long as the shortname is unambiguous) of an existing Okta user
       * @param sendEmail
       * @param revokeSessions Revokes all user sessions, except for the current session, if set to &#x60;true&#x60;
+      * @param provider Specifies the authentication provider to use when converting a user to a federated user. Use &#x60;FEDERATION&#x60; to convert an Okta-credentialed user to a federated user. After conversion, the user can\&#39;t directly sign in with a password and must authenticate through a trusted identity provider.
       */
-  generateResetPasswordToken(userId: string, sendEmail: boolean, revokeSessions?: boolean, _options?: Configuration): Observable<ResetPasswordToken>;
+  generateResetPasswordToken(userId: string, sendEmail: boolean, revokeSessions?: boolean, provider?: AuthenticationProviderType, _options?: Configuration): Observable<ResetPasswordToken>;
   /**
       * Retrieves a linked identity provider (IdP) user by ID
       * Retrieve a user for IdP

--- a/src/types/generated/types/PromiseAPI.d.ts
+++ b/src/types/generated/types/PromiseAPI.d.ts
@@ -53,6 +53,7 @@ import { AssignedAppLink } from '../models/AssignedAppLink';
 import { AssociatedServerMediated } from '../models/AssociatedServerMediated';
 import { AttackProtectionAuthenticatorSettings } from '../models/AttackProtectionAuthenticatorSettings';
 import { AuthSettings } from '../models/AuthSettings';
+import { AuthenticationProviderType } from '../models/AuthenticationProviderType';
 import { AuthenticatorBase } from '../models/AuthenticatorBase';
 import { AuthenticatorEnrollment } from '../models/AuthenticatorEnrollment';
 import { AuthenticatorEnrollmentCreateRequest } from '../models/AuthenticatorEnrollmentCreateRequest';
@@ -5699,8 +5700,9 @@ export declare class PromiseUserApi {
       * @param userId An ID, login, or login shortname (as long as the shortname is unambiguous) of an existing Okta user
       * @param sendEmail
       * @param revokeSessions Revokes all user sessions, except for the current session, if set to &#x60;true&#x60;
+      * @param provider Specifies the authentication provider to use when converting a user to a federated user. Use &#x60;FEDERATION&#x60; to convert an Okta-credentialed user to a federated user. After conversion, the user can\&#39;t directly sign in with a password and must authenticate through a trusted identity provider.
       */
-  generateResetPasswordToken(userId: string, sendEmail: boolean, revokeSessions?: boolean, _options?: Configuration): Promise<ResetPasswordToken>;
+  generateResetPasswordToken(userId: string, sendEmail: boolean, revokeSessions?: boolean, provider?: AuthenticationProviderType, _options?: Configuration): Promise<ResetPasswordToken>;
   /**
       * Retrieves a linked identity provider (IdP) user by ID
       * Retrieve a user for IdP

--- a/test/unit/user-request-factory-additional.ts
+++ b/test/unit/user-request-factory-additional.ts
@@ -588,6 +588,40 @@ describe('UserApi Request Factory - Additional Coverage', () => {
     });
   });
 
+  describe('generateResetPasswordToken', () => {
+    it('should not throw RequiredError when provider is omitted', async () => {
+      try {
+        await factory.generateResetPasswordToken('user123', true);
+      } catch (error: any) {
+        expect(error.name).to.not.equal('RequiredError');
+      }
+    });
+
+    it('should not throw RequiredError when provider is FEDERATION', async () => {
+      try {
+        await factory.generateResetPasswordToken('user123', false, undefined, 'FEDERATION' as any);
+      } catch (error: any) {
+        expect(error.name).to.not.equal('RequiredError');
+      }
+    });
+
+    it('should not throw RequiredError when provider is undefined', async () => {
+      try {
+        await factory.generateResetPasswordToken('user123', true, false, undefined);
+      } catch (error: any) {
+        expect(error.name).to.not.equal('RequiredError');
+      }
+    });
+
+    it('should not throw RequiredError with all parameters set', async () => {
+      try {
+        await factory.generateResetPasswordToken('user123', false, true, 'FEDERATION' as any);
+      } catch (error: any) {
+        expect(error.name).to.not.equal('RequiredError');
+      }
+    });
+  });
+
   describe('revokeGrantsForUserAndClient', () => {
     it('should throw RequiredError when userId is null', async () => {
       try {

--- a/test/unit/user-request-factory.ts
+++ b/test/unit/user-request-factory.ts
@@ -174,6 +174,15 @@ describe('UserApiRequestFactory', () => {
         expect(error.message).to.include('userId');
       }
     });
+
+    it('should throw error when sendEmail is null', async () => {
+      try {
+        await factory.generateResetPasswordToken('user123', null as any, false);
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error.message).to.include('sendEmail');
+      }
+    });
   });
 
   describe('getIdentityProviderApplicationUser', () => {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

The `generateResetPasswordToken` method does not expose the `provider` query parameter in the SDK. As a result, callers cannot use the API's federation conversion feature — converting an Okta-credentialed user to a federated user — via the SDK.

Issue Number: OKTA-1141679

## What is the new behavior?

The `provider` query parameter (`AuthenticationProviderType`) is now exposed as an optional argument on `generateResetPasswordToken`. Passing `provider=FEDERATION` converts the user's credential provider to federated, after which they must authenticate through a trusted identity provider and can no longer sign in directly with a password.

This was verified live against the Okta API — calling with `provider=FEDERATION` returns HTTP 200 and the user's `credentials.provider.type` changes to `FEDERATION`.

## Does this PR introduce a breaking change?

- [x] No

The new parameter is optional and fully backward compatible. Existing callers omitting `provider` see no change in behavior.

## Other information

- The same parameter is missing from `okta-sdk-dotnet` — a separate issue should be filed there.
- The OAS spec (management.yaml and management.yaml) was updated and the SDK was regenerated.

## Reviewers