### PR TITLE
fix: ProfileMapping properties serialized as empty object

### DIFF
--- a/oas-spec/management.yaml
+++ b/oas-spec/management.yaml
@@ -77322,8 +77322,9 @@ components:
           description: Unique identifier for a profile mapping
           readOnly: true
         properties:
-          $ref: '#/components/schemas/ProfileMappingProperty'
-          readOnly: false
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ProfileMappingProperty'
         source:
           $ref: '#/components/schemas/ProfileMappingSource'
         target:
@@ -77354,11 +77355,11 @@ components:
       type: object
       properties:
         properties:
-          $ref: '#/components/schemas/ProfileMappingProperty'
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/ProfileMappingProperty'
       required:
         - properties
-        - expression
-        - pushStatus
     ProfileMappingSource:
       description: |-
         The parameter is the source of a profile mapping and is a valid [JSON Schema Draft 4](https://datatracker.ietf.org/doc/html/draft-zyp-json-schema-04) document with the following properties. The data type can be an app instance or an Okta object.

--- a/src/generated/models/ProfileMapping.js
+++ b/src/generated/models/ProfileMapping.js
@@ -47,7 +47,7 @@ ProfileMapping.attributeTypeMap = [
   {
     'name': 'properties',
     'baseName': 'properties',
-    'type': 'ProfileMappingProperty',
+    'type': '{ [key: string]: ProfileMappingProperty; }',
     'format': ''
   },
   {

--- a/src/generated/models/ProfileMappingRequest.js
+++ b/src/generated/models/ProfileMappingRequest.js
@@ -41,7 +41,7 @@ ProfileMappingRequest.attributeTypeMap = [
   {
     'name': 'properties',
     'baseName': 'properties',
-    'type': 'ProfileMappingProperty',
+    'type': '{ [key: string]: ProfileMappingProperty; }',
     'format': ''
   }
 ];

--- a/src/types/generated/models/ProfileMapping.d.ts
+++ b/src/types/generated/models/ProfileMapping.d.ts
@@ -34,7 +34,9 @@ export declare class ProfileMapping {
     * Unique identifier for a profile mapping
     */
   'id'?: string;
-  'properties'?: ProfileMappingProperty;
+  'properties'?: {
+        [key: string]: ProfileMappingProperty;
+    };
   'source'?: ProfileMappingSource;
   'target'?: ProfileMappingTarget;
   '_links'?: LinksSelf;

--- a/src/types/generated/models/ProfileMappingRequest.d.ts
+++ b/src/types/generated/models/ProfileMappingRequest.d.ts
@@ -27,7 +27,9 @@ import { ProfileMappingProperty } from './../models/ProfileMappingProperty';
 * The updated request body properties
 */
 export declare class ProfileMappingRequest {
-  'properties': ProfileMappingProperty;
+  'properties': {
+        [key: string]: ProfileMappingProperty;
+    };
   static readonly discriminator: string | undefined;
   static readonly attributeTypeMap: Array<{
         name: string;

--- a/test/type/profile-mapping-api.test-d.ts
+++ b/test/type/profile-mapping-api.test-d.ts
@@ -18,6 +18,6 @@ const client = new Client();
   const profileMappingRequest = profileMapping as ProfileMappingRequest;
   profileMapping = await client.profileMappingApi.updateProfileMapping({mappingId: 'mappingId', profileMapping: profileMappingRequest});
   if (profileMapping && profileMapping.properties) {
-    expectType<ProfileMappingProperty>(profileMapping.properties);
+    expectType<{ [key: string]: ProfileMappingProperty }>(profileMapping.properties);
   }
 }());

--- a/test/unit/profile-mapping-serialization.ts
+++ b/test/unit/profile-mapping-serialization.ts
@@ -1,0 +1,112 @@
+/*!
+ * Copyright (c) 2017-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { ObjectSerializer } from '../../src/generated/models/ObjectSerializer';
+
+// Regression test for: ProfileMapping(Request).properties serialized as empty object
+// Root cause: attributeTypeMap declared 'properties' as 'ProfileMappingProperty' (single object)
+// instead of '{ [key: string]: ProfileMappingProperty; }' (map), causing all custom attribute
+// keys to be discarded by the serializer.
+
+describe('ProfileMapping serialization', () => {
+  describe('ProfileMappingRequest', () => {
+    it('preserves custom property keys during serialization', () => {
+      const input = {
+        properties: {
+          logoutRedirectURL: {
+            expression: '"https://example.com/logout"',
+            pushStatus: 'PUSH'
+          },
+          login: {
+            expression: 'appuser.userName',
+            pushStatus: 'DONT_PUSH'
+          }
+        }
+      };
+
+      const serialized = ObjectSerializer.serialize(input, 'ProfileMappingRequest', '');
+
+      expect(serialized).to.have.property('properties');
+      expect(serialized.properties).to.have.all.keys('logoutRedirectURL', 'login');
+      expect(serialized.properties.logoutRedirectURL).to.deep.equal({
+        expression: '"https://example.com/logout"',
+        pushStatus: 'PUSH'
+      });
+      expect(serialized.properties.login).to.deep.equal({
+        expression: 'appuser.userName',
+        pushStatus: 'DONT_PUSH'
+      });
+    });
+
+    it('does not send an empty properties object when properties are provided', () => {
+      const input = {
+        properties: {
+          myAttribute: {
+            expression: '"https://example.com"',
+            pushStatus: 'PUSH'
+          }
+        }
+      };
+
+      const serialized = ObjectSerializer.serialize(input, 'ProfileMappingRequest', '');
+
+      expect(Object.keys(serialized.properties)).to.have.length(1);
+      expect(serialized.properties).to.have.property('myAttribute');
+    });
+
+    it('serializes an empty properties map as empty object', () => {
+      const input = { properties: {} };
+
+      const serialized = ObjectSerializer.serialize(input, 'ProfileMappingRequest', '');
+
+      expect(serialized).to.have.property('properties');
+      expect(serialized.properties).to.deep.equal({});
+    });
+  });
+
+  describe('ProfileMapping deserialization', () => {
+    it('preserves custom property keys during deserialization', () => {
+      const raw = {
+        id: 'prm123',
+        properties: {
+          logoutRedirectURL: {
+            expression: '"https://example.com/logout"',
+            pushStatus: 'PUSH'
+          }
+        }
+      };
+
+      const deserialized = ObjectSerializer.deserialize(raw, 'ProfileMapping', '');
+
+      expect(deserialized.properties).to.have.property('logoutRedirectURL');
+      expect(deserialized.properties.logoutRedirectURL.expression).to.equal('"https://example.com/logout"');
+      expect(deserialized.properties.logoutRedirectURL.pushStatus).to.equal('PUSH');
+    });
+
+    it('deserializes multiple custom properties correctly', () => {
+      const raw = {
+        id: 'prm456',
+        properties: {
+          firstName: { expression: 'appuser.firstName', pushStatus: 'PUSH' },
+          lastName:  { expression: 'appuser.lastName',  pushStatus: 'PUSH' },
+          email:     { expression: 'appuser.email',     pushStatus: 'DONT_PUSH' }
+        }
+      };
+
+      const deserialized = ObjectSerializer.deserialize(raw, 'ProfileMapping', '');
+
+      expect(deserialized.properties).to.have.all.keys('firstName', 'lastName', 'email');
+      expect(deserialized.properties.email.pushStatus).to.equal('DONT_PUSH');
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other...

## What is the current behavior?

Issue Number: N/A

When calling `profileMappingApi.updateProfileMapping()` with a `properties` map containing custom attribute names (e.g. `logoutRedirectURL`, `login`), the SDK silently strips all property keys and sends `"properties": {}` to the API. The API returns `200 OK` with no error, making the update appear successful while no mapping changes are actually applied.

Root cause: `ProfileMapping` and `ProfileMappingRequest` declared `properties` as type `ProfileMappingProperty` (a single object) in their `attributeTypeMap`. The `ObjectSerializer` treated the entire map as a single typed object, looked up only the known fields `expression` and `pushStatus` at the top level, found nothing, and discarded all custom keys.

## What is the new behavior?

- `ProfileMapping.properties` and `ProfileMappingRequest.properties` are now correctly typed as `{ [key: string]: ProfileMappingProperty }` (a map).
- The `ObjectSerializer` now iterates over all keys in the map and serializes each value correctly, preserving custom attribute names in the outgoing request body.
- The OAS spec (`oas-spec/management.yaml`) is updated to use `additionalProperties` for both schemas, so the fix is preserved on future SDK regeneration.
- The erroneous `required: [expression, pushStatus]` entries are removed from `ProfileMappingRequest` — those fields belong to `ProfileMappingProperty` (the value type), not the request wrapper.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

**Files changed:**
- `oas-spec/management.yaml` — corrected OAS schema for `ProfileMapping` and `ProfileMappingRequest`; used as the committed spec backup and kept in sync with `spec/management.yaml`
- `src/generated/models/ProfileMapping.js` — `attributeTypeMap` type updated to map type
- `src/generated/models/ProfileMappingRequest.js` — same
- `src/types/generated/models/ProfileMapping.d.ts` — TypeScript declaration updated to map type
- `src/types/generated/models/ProfileMappingRequest.d.ts` — same
- `test/type/profile-mapping-api.test-d.ts` — `expectType` assertion updated to match corrected map type
- `test/unit/profile-mapping-serialization.ts` — new regression tests (5) covering serialization and deserialization of map properties
