### PR TITLE
fix: preserve agent instance when building retry request

### DIFF
--- a/src/default-request-executor.js
+++ b/src/default-request-executor.js
@@ -33,7 +33,11 @@ class DefaultRequestExecutor extends RequestExecutor {
 
   buildRetryRequest(request, requestId, delayMs) {
     const elapsedMs = Date.now() - request.startTime;
-    const newRequest = deepCopy(request);
+    const { agent, ...rest } = request;
+    const newRequest = deepCopy(rest);
+    if (agent) {
+      newRequest.agent = agent;
+    }
     newRequest.timeout = this.requestTimeout > 0 ? this.requestTimeout - elapsedMs - delayMs : 0;
     if (!newRequest.headers) {
       newRequest.headers = {};

--- a/test/jest/default-request-executor.test.js
+++ b/test/jest/default-request-executor.test.js
@@ -137,6 +137,35 @@ describe('DefaultRequestExecutor', () => {
       expect(newRequest.timeout).toEqual(0);
     });
 
+    it('should preserve the original agent instance on the retry request', () => {
+      const requestExecutor = new DefaultRequestExecutor();
+      // Simulate an HttpsProxyAgent-like object (class instance with prototype methods)
+      class FakeAgent {
+        addRequest() {}
+      }
+      const agent = new FakeAgent();
+      const mockRequest = {
+        method: 'GET',
+        headers: {},
+        startTime: new Date(),
+        agent
+      };
+      const newRequest = requestExecutor.buildRetryRequest(mockRequest, 'req-id-123', 0);
+      expect(newRequest.agent).toBe(agent);
+      expect(newRequest.agent).toBeInstanceOf(FakeAgent);
+    });
+
+    it('should not set agent on the retry request if the original had none', () => {
+      const requestExecutor = new DefaultRequestExecutor();
+      const mockRequest = {
+        method: 'GET',
+        headers: {},
+        startTime: new Date()
+      };
+      const newRequest = requestExecutor.buildRetryRequest(mockRequest, 'req-id-456', 0);
+      expect(newRequest.agent).toBeUndefined();
+    });
+
   });
 
   describe('validateRetryResponseHeaders', () => {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other...

## What is the current behavior?

Issue Number: https://github.com/okta/okta-sdk-nodejs/issues/478

When `HTTPS_PROXY` (or `https_proxy`) is set and a request is retried (e.g. after a 429 rate-limit response), the retry fails with:

```
The "options.agent" property must be one of Agent-like Object, undefined, or false. Received an instance of Object
```

Root cause: `http.js` sets `request.agent` to an `HttpsProxyAgent` class instance. In `DefaultRequestExecutor.buildRetryRequest()`, the entire request object is cloned via `deepCopy()`, which strips the prototype chain from the agent — leaving a plain `{}` instead of a proper `HttpsProxyAgent` instance. Node's `http`/`https` module then rejects the invalid agent on the retry.

## What is the new behavior?

- `buildRetryRequest` now extracts the `agent` from the request before deep-copying the rest of the fields.
- The original `agent` instance is restored onto the cloned request after the deep copy.
- This preserves the `HttpsProxyAgent` prototype chain, satisfying Node's agent validation on retries.
- When no proxy is configured (`agent` is absent), behaviour is completely unchanged.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

**Files changed:**
- `src/default-request-executor.js` — extract `agent` before `deepCopy`, restore original instance on the retry request
- `test/jest/default-request-executor.test.js` — two new tests: one asserting the agent instance (and prototype) is preserved on retry, one asserting no agent is set when the original request had none
