### PR TITLE
docs: add 8.1.0 changelog and move migration guide to MIGRATING.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Okta Node SDK Changelog
 
+# 8.1.0
+
+### Fixes
+
+- [#472](https://github.com/okta/okta-sdk-nodejs/pull/472) fix: TypeScript Compilation errors - Fixed `IdentityProviderProtocol` discriminated union where the `type` discriminant property was incorrectly generated as optional (`type?:`) in 5 protocol subtypes (`ProtocolOidc`, `ProtocolSaml`, `ProtocolMtls`, `ProtocolOAuth`, `ProtocolIdVerification`). TypeScript can now properly narrow the union by `type`, making subtype-specific properties (e.g. `issuer`, `authorization`, `signing`) accessible after a type guard check.
+
+  > **Note for TypeScript consumers:** If you were constructing a Protocol subtype object without an explicit `type` field, TypeScript will now report a compile-time error. Add the appropriate `type` literal (e.g. `type: 'OIDC'`) to fix this.
+
+- [#473](https://github.com/okta/okta-sdk-nodejs/pull/473) fix: support ESM named imports - Explicit named exports for `Client`, `RequestExecutor`, `DefaultRequestExecutor`, `Collection`, `MemoryStore`, and `OktaApiError` are now assigned individually on `module.exports` before the generated exports are merged. This allows bundlers (webpack, rollup) and ESM interop tools to statically enumerate and tree-shake individual named exports.
+
+- [#474](https://github.com/okta/okta-sdk-nodejs/pull/474) fix: upgrade lodash to 4.17.23 - Resolves a prototype pollution vulnerability (CVE-2025-13465) in `lodash@^4.17.20` via the `_.unset` and `_.omit` functions.
+
+- [#487](https://github.com/okta/okta-sdk-nodejs/pull/487) fix: ProfileMapping properties serialized as empty object - Fixed a silent data-loss bug where calling `profileMappingApi.updateProfileMapping()` with a `properties` map containing custom attribute names (e.g. `logoutRedirectURL`, `login`) would send `"properties": {}` to the API. The `ObjectSerializer` was treating the entire map as a single typed object and discarding all custom keys. `ProfileMapping.properties` and `ProfileMappingRequest.properties` are now correctly typed as `{ [key: string]: ProfileMappingProperty }`.
+
+  > **Note for TypeScript consumers:** The TypeScript type of `ProfileMapping.properties` and `ProfileMappingRequest.properties` has changed from `ProfileMappingProperty` to `{ [key: string]: ProfileMappingProperty }`. Update any type annotations accordingly.
+
+- [#488](https://github.com/okta/okta-sdk-nodejs/pull/488) fix: preserve agent instance when building retry request - Fixed a crash that occurred when `HTTPS_PROXY` (or `https_proxy`) was set and a request was retried (e.g. after a 429 rate-limit response). The `deepCopy()` call in `buildRetryRequest` stripped the `HttpsProxyAgent` prototype chain, causing Node's `http`/`https` module to reject the retry with `The "options.agent" property must be one of Agent-like Object, undefined, or false. Received an instance of Object`. The original `agent` instance is now preserved across retries.
+
+- [#489](https://github.com/okta/okta-sdk-nodejs/pull/489) fix: add missing `items` field to `UserSchemaAttribute` - Fixed an issue where calling `schemaApi.updateApplicationUserProfile` with a custom attribute of `type: 'array'` would cause the API to reject the request with `Items not present for array property`. The `items` field (typed as `UserSchemaAttributeItems`) was accidentally dropped from `UserSchemaAttribute` during the v4→v5 spec update. It is now restored, consistent with `GroupSchemaAttribute`.
+
+### Dependencies
+
+- [#476](https://github.com/okta/okta-sdk-nodejs/pull/476) chore: upgrade mocha to v10.8.2 - Resolves security vulnerabilities in transitive dependencies that were blocked by Mocha v9.
+- [#481](https://github.com/okta/okta-sdk-nodejs/pull/481) chore(deps): bump `flatted` from 3.3.3 to 3.4.2
+- [#482](https://github.com/okta/okta-sdk-nodejs/pull/482) chore(deps): bump `picomatch` from 2.3.1 to 2.3.2
+- [#484](https://github.com/okta/okta-sdk-nodejs/pull/484) chore(deps-dev): bump `node-forge` from 1.3.3 to 1.4.0
+- [#486](https://github.com/okta/okta-sdk-nodejs/pull/486) chore(deps): bump `lodash` from 4.17.23 to 4.18.1
+
 # 8.0.0
 
 ### Features

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -11,7 +11,6 @@ Version 8.1.0 contains no breaking API changes. The following TypeScript type co
 ### 1. `IdentityProviderProtocol` discriminant `type` is now required
 
 The `type` property on the five `IdentityProviderProtocol` subtypes (`ProtocolOidc`, `ProtocolSaml`, `ProtocolMtls`, `ProtocolOAuth`, `ProtocolIdVerification`) is now correctly marked as required (was incorrectly optional due to a code-generator bug). This matches the Okta API spec.
-
 If your TypeScript code constructs a Protocol object without an explicit `type` field, add the appropriate discriminant literal:
 
 ```typescript

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,0 +1,228 @@
+# Okta Node.js SDK — Migration Guide
+
+This document covers upgrading between major and minor versions of `@okta/okta-sdk-nodejs`.
+
+---
+
+## From 8.0 to 8.1
+
+Version 8.1.0 contains no breaking API changes. The following TypeScript type corrections may require minor updates in TypeScript codebases:
+
+### 1. `IdentityProviderProtocol` discriminant `type` is now required
+
+The `type` property on the five `IdentityProviderProtocol` subtypes (`ProtocolOidc`, `ProtocolSaml`, `ProtocolMtls`, `ProtocolOAuth`, `ProtocolIdVerification`) is now correctly marked as required (was incorrectly optional due to a code-generator bug). This matches the Okta API spec.
+
+If your TypeScript code constructs a Protocol object without an explicit `type` field, add the appropriate discriminant literal:
+
+```typescript
+// Before (compiled without error in 8.0 even though 'type' was required by the API)
+const protocol: ProtocolOidc = { /* no type field */ };
+
+// After (8.1) — add the required discriminant
+const protocol: ProtocolOidc = { type: 'OIDC', /* ... */ };
+```
+
+### 2. `ProfileMapping.properties` and `ProfileMappingRequest.properties` type corrected
+
+The TypeScript type of the `properties` field has changed from `ProfileMappingProperty` (single object, incorrect) to `{ [key: string]: ProfileMappingProperty }` (map, correct). This was a bug fix — the old type caused all custom attribute keys to be silently dropped when serializing.
+
+```typescript
+// Before (8.0) — incorrect type caused silent data loss at runtime
+const request: ProfileMappingRequest = {
+  properties: { expression: 'user.login', pushStatus: 'PUSH' } as ProfileMappingProperty
+};
+
+// After (8.1) — correct map type, custom attributes are preserved
+const request: ProfileMappingRequest = {
+  properties: {
+    login: { expression: 'user.login', pushStatus: 'PUSH' },
+    email: { expression: 'user.email', pushStatus: 'PUSH' }
+  }
+};
+```
+
+---
+
+## From 7.x to 8.0
+
+### Breaking Changes
+
+Version 8.0 includes several breaking changes due to updates in the Okta OpenAPI specification:
+
+#### 1. Email Server API — Property Renamed
+
+The `EmailTestAddresses` model has been updated with renamed properties:
+
+**Old (v7.x):**
+```javascript
+await client.emailServerApi.testEmailServer({
+  emailServerId: emailServer.id,
+  emailTestAddresses: {
+    _from: 'test@example.com',
+    to: 'recipient@example.com'
+  }
+});
+```
+
+**New (v8.0):**
+```javascript
+await client.emailServerApi.testEmailServer({
+  emailServerId: emailServer.id,
+  emailTestAddresses: {
+    fromAddress: 'test@example.com',  // Changed from '_from'
+    to: 'recipient@example.com'
+  }
+});
+```
+
+#### 2. Custom Role API — Model Renamed
+
+The `CustomRole` model has been renamed to `IamRole`:
+
+**Old (v7.x):**
+```javascript
+import { CustomRole } from '@okta/okta-sdk-nodejs';
+
+let customRole: CustomRole;
+```
+
+**New (v8.0):**
+```javascript
+import { IamRole } from '@okta/okta-sdk-nodejs';
+
+let customRole: IamRole;  // Changed from CustomRole
+```
+
+#### 3. Role Assignment API — Model Renamed
+
+The `AssignRoleRequest` model has been renamed to `StandardRoleAssignmentSchema`:
+
+**Old (v7.x):**
+```javascript
+import { AssignRoleRequest } from '@okta/okta-sdk-nodejs';
+
+const roleRequest: AssignRoleRequest = {
+  type: 'USER_ADMIN'
+};
+
+await client.userApi.assignRoleToUser({
+  userId: user.id,
+  assignRoleRequest: roleRequest
+});
+```
+
+**New (v8.0):**
+```javascript
+import { StandardRoleAssignmentSchema } from '@okta/okta-sdk-nodejs';
+
+const roleRequest: StandardRoleAssignmentSchema = {  // Changed from AssignRoleRequest
+  type: 'USER_ADMIN'
+};
+
+await client.userApi.assignRoleToUser({
+  userId: user.id,
+  assignRoleRequest: roleRequest
+});
+```
+
+### New APIs Added in 8.0
+
+- **AgentConnectionsApi** — Manage agent connections
+- **AgentPotentialConnectionsApi** — Discover potential agent connections
+- **AgentPublicKeyApi** — Manage agent public keys
+- **AgentRegistrationApi** — Handle agent registration
+- **ApplicationCrossAppAccessConnectionsApi** — Manage cross-app access connections
+- **ApplicationInterclientTrustMappingsApi** — Configure interclient trust mappings
+- **ApplicationSSOPublicKeysApi** — Manage application SSO public keys
+- **AssociatedDomainCustomizationsApi** — Customize associated domains
+- **CustomTelephonyProviderApi** — Configure custom telephony providers
+- **GroupPushMappingApi** — Manage group push mappings
+- **OAuth2ResourceServerCredentialsKeysApi** — Manage OAuth2 resource server credentials
+- **OktaManagedUserAccountApi** — Manage Okta managed user accounts
+- **OperationsIntegrationApi** — Handle operations integrations
+- **UserAuthenticatorEnrollmentsApi** — Manage user authenticator enrollments
+
+### API Enhancements in 8.0
+
+- **ApplicationApi** — Enhanced with additional methods for improved application management
+- **AuthenticatorApi** — Expanded authenticator management capabilities
+- **IdentitySourceApi** — Significantly enhanced with extensive new methods for identity source operations
+- **YourOinIntegrationsApi** — Enhanced integration management features
+
+---
+
+## From 6.x to 7.0
+
+### Breaking changes
+
+- Methods are invoked on scoped clients
+- Method params are passed as a single object
+- Models no longer have CRUD methods
+- Methods which return `Collection` become async
+- Enums are replaced with union types
+- Model properties are optional
+
+```diff
+- await client.getUser('ausmvdt5xg8wRVI1d0g3')
++ await client.userApi.getUser({ userId: 'ausmvdt5xg8wRVI1d0g3' })
+```
+
+```diff
+- await user.deactivate()
++ await client.userApi.deactivateUser({ userId: user.id })
+```
+
+---
+
+## From 5.x to 6.0
+
+### Breaking changes
+
+Enum types from the spec are accounted for: respective JS models are converted to enum-like modules.
+
+Following Client method signatures have changed:
+- `listPolicies` returns `Promise<Policy>`
+- `activateNetworkZone` returns `Promise<NetworkZone>`
+- `deactivateNetworkZone` returns `Promise<NetworkZone>`
+- `listGroups` no longer accepts `filter` parameter through `queryParameters`
+
+---
+
+## From 4.x to 5.0
+
+The version 5.0 of this SDK dropped support for Node 10, which is EOL (End-of-Life) since 2021-04-30. Current supported minimal Node version is 12.0.0.
+
+### Breaking changes
+
+Following Client method signatures have changed:
+- `createAuthorizationServerPolicy`: added `authorizationServerPolicy: AuthorizationServerPolicyOptions` parameter
+- `listAuthorizationServerPolicies`: returns `Collection<AuthorizationServerPolicy>`
+- `getAuthorizationServerPolicy`: returns `Promise<AuthorizationServerPolicy>`
+- `updateAuthorizationServerPolicy`: second parameter type changed to `AuthorizationServerPolicyOptions`, returns `Promise<AuthorizationServerPolicy>`
+- `listPolicies` returns `Promise<AuthorizationServerPolicy>`
+
+Following models' method signatures have changed:
+- `AuthorizationServer`
+
+Change details are listed in [CHANGELOG.md](CHANGELOG.md#500).
+
+All required method parameters in Client are now checked at runtime in JS code.
+
+---
+
+## From 3.x to 4.0
+
+The version 4.0 of this SDK dropped support for Node 8, which is EOL (End-of-Life) since 2019-12-31. Current supported minimum Node version is 10.0.0.
+
+This version 4.0 release also updated APIs to the latest `@okta/openapi` (v2.0.0) which includes added, changed and deprecated factories/models/client methods. Change details are listed in [CHANGELOG.md](CHANGELOG.md#400). For each change item:
+
+- `Add` — newly added factories/models/client methods.
+- `Change` (**breaking changes**) — renamed factories/models/client methods.
+- `Remove` (**breaking changes**) — deprecated factories/models/client methods.
+
+### Main breaking changes
+
+- Renamed `Factor` related factories/models/client methods to `UserFactor`
+- Renamed `client.sessionApi.endAllUserSessions` to `client.sessionApi.clearUserSessions`
+- Model and Client methods change for `User` related operations
+- Model and Client methods change for `Rule` related operations

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This library uses semantic versioning and follows Okta's [library version policy
 | 5.x | :x: Retired |
 | 6.x | :x: Retired |
 | 7.x | :x: Retired |
-| 8.x | :heavy_check_mark: Stable ([migration guide](#from-7x-to-80)) |
+| 8.x | :heavy_check_mark: Stable ([migration guide](MIGRATING.md)) |
 
 The latest release can always be found on the [releases page][github-releases].
  
@@ -934,7 +934,7 @@ const application: BookmarkApplication = client.createApplication(applicationOpt
 API methods should be called from corresponding API object of `client`. 
 Params should be passed as a single object. 
 
-See [migration guide](#from-6x-to-70)
+See [migration guide](MIGRATING.md#from-6x-to-70)
 
 ```typescript
 const application: BookmarkApplication = {
@@ -974,196 +974,7 @@ const client: Client = new Client({
 
 ## Migrating between versions
 
-### From 7.x to 8.0
-
-#### Breaking Changes
-
-Version 8.0 includes several breaking changes due to updates in the Okta OpenAPI specification:
-
-##### 1. Email Server API - Property Renamed
-
-The `EmailTestAddresses` model has been updated with renamed properties:
-
-**Old (v7.x):**
-```javascript
-await client.emailServerApi.testEmailServer({
-  emailServerId: emailServer.id,
-  emailTestAddresses: {
-    _from: 'test@example.com',
-    to: 'recipient@example.com'
-  }
-});
-```
-
-**New (v8.0):**
-```javascript
-await client.emailServerApi.testEmailServer({
-  emailServerId: emailServer.id,
-  emailTestAddresses: {
-    fromAddress: 'test@example.com',  // Changed from '_from'
-    to: 'recipient@example.com'
-  }
-});
-```
-
-##### 2. Custom Role API - Model Renamed
-
-The `CustomRole` model has been renamed to `IamRole`:
-
-**Old (v7.x):**
-```javascript
-import { CustomRole } from '@okta/okta-sdk-nodejs';
-
-let customRole: CustomRole;
-```
-
-**New (v8.0):**
-```javascript
-import { IamRole } from '@okta/okta-sdk-nodejs';
-
-let customRole: IamRole;  // Changed from CustomRole
-```
-
-##### 3. Role Assignment API - Model Renamed
-
-The `AssignRoleRequest` model has been renamed to `StandardRoleAssignmentSchema`:
-
-**Old (v7.x):**
-```javascript
-import { AssignRoleRequest } from '@okta/okta-sdk-nodejs';
-
-const roleRequest: AssignRoleRequest = {
-  type: 'USER_ADMIN'
-};
-
-await client.userApi.assignRoleToUser({
-  userId: user.id,
-  assignRoleRequest: roleRequest
-});
-```
-
-**New (v8.0):**
-```javascript
-import { StandardRoleAssignmentSchema } from '@okta/okta-sdk-nodejs';
-
-const roleRequest: StandardRoleAssignmentSchema = {  // Changed from AssignRoleRequest
-  type: 'USER_ADMIN'
-};
-
-await client.userApi.assignRoleToUser({
-  userId: user.id,
-  assignRoleRequest: roleRequest
-});
-```
-
-#### New APIs Added
-
-Version 8.0 introduces several new API endpoints:
-
-- **AgentConnectionsApi** - Manage agent connections
-- **AgentPotentialConnectionsApi** - Discover potential agent connections
-- **AgentPublicKeyApi** - Manage agent public keys
-- **AgentRegistrationApi** - Handle agent registration
-- **ApplicationCrossAppAccessConnectionsApi** - Manage cross-app access connections
-- **ApplicationInterclientTrustMappingsApi** - Configure interclient trust mappings
-- **ApplicationSSOPublicKeysApi** - Manage application SSO public keys
-- **AssociatedDomainCustomizationsApi** - Customize associated domains
-- **CustomTelephonyProviderApi** - Configure custom telephony providers
-- **GroupPushMappingApi** - Manage group push mappings
-- **OAuth2ResourceServerCredentialsKeysApi** - Manage OAuth2 resource server credentials
-- **OktaManagedUserAccountApi** - Manage Okta managed user accounts
-- **OperationsIntegrationApi** - Handle operations integrations
-- **UserAuthenticatorEnrollmentsApi** - Manage user authenticator enrollments
-
-#### API Enhancements
-
-- **ApplicationApi** - Enhanced with additional methods for improved application management
-- **AuthenticatorApi** - Expanded authenticator management capabilities
-- **IdentitySourceApi** - Significantly enhanced with extensive new methods for identity source operations
-- **YourOinIntegrationsApi** - Enhanced integration management features
-
-To use the new APIs:
-
-```javascript
-const client = new okta.Client({
-  orgUrl: 'https://dev-1234.okta.com',
-  token: 'YOUR_API_TOKEN'
-});
-
-// Example: Use the new AgentConnectionsApi
-const connections = await client.agentConnectionsApi.listAgentConnections({ poolId: 'poolId' });
-
-```
-
-### From 6.x to 7.0
-
-#### Breaking changes
-
- - Methods are invoked on scoped clients
- - Method params are passed as a single object
- - Models no longer have CRUD methods
- - Methods which return `Collection` become async
- - Enums are replaced with union types
- - Model properties are optional
-
-```diff
-- await client.getUser('ausmvdt5xg8wRVI1d0g3')
-+ await client.userApi.getUser({ userId: 'ausmvdt5xg8wRVI1d0g3' })
-```
-
-```diff
-- await user.deactivate()
-+ await client.userApi.deactivateUser({ userId: user.id })
-```
-
-### From 5.x to 6.0
-
-#### Breaking changes
-
-Enum types from the spec are accounted for: repspective JS models are converted to enum-like modules.
-
-Following Client methods signatures have changed:
- - `listPolicies` returns `Promise<Policy>`
- - `activateNetworkZone` returns `Promise<NetworkZone>`
- - `deactivateNetworkZone` returns `Promise<NetworkZone>`
- - `listGroups` no longer accepts `filter` parameter trhough `queryParameters`
-
-### From 4.x to 5.0
-
-The version 5.0 of this SDK dropped support for Node 10, which is EOL (End-of-Life) since 2021-04-30. Current supported minimal Node version is 12.0.0.
-
-#### Breaking changes
-
-Following Client methods signatures have changed:
- - `createAuthorizationServerPolicy`: added `authorizationServerPolicy: AuthorizationServerPolicyOptions` parameter
- - `listAuthorizationServerPolicies`: returns `Collection<AuthorizationServerPolicy>`
- - `getAuthorizationServerPolicy`: returns `Promise<AuthorizationServerPolicy>`
- - `updateAuthorizationServerPolicy`: second parameter type changed to `AuthorizationServerPolicyOptions`, returns `Promise<AuthorizationServerPolicy>`
- - `listPolicies` returns `Promise<AuthorizationServerPolicy>`
-
-Following models' method signatures have changed:
-- `AuthorizationServer`
-
- Change details are listed in [CHANGELOG.md](CHANGELOG.md#500)
-
-All required method parameters in Client are now checked at runtime in JS code.
-
-### From 3.x to 4.0
-
-The version 4.0 of this SDK dropped support for Node 8, which is EOL (End-of-Life) since 2019-12-31. Current supported minimum Node version is 10.0.0.
-
-This version 4.0 release also updated APIs latest `@okta/openapi` (v2.0.0) that includes added, changed and deprecated factories/models/client methods. Change details are listed in [CHANGELOG.md](CHANGELOG.md#400). For each change item:
-
-- `Add` stands for newly added factories/models/client methods.
-- `Change` (**breaking changes**) stands for renamed factories/models/client methods.
-- `Remove` (**breaking changes**) stands for deprecated factories/models/client methods.
-
-#### Main breaking changes
-
-- Renamed `Factor` related factories/models/client methods to `UserFactor`
-- Renamed `client.sessionApi.endAllUserSessions` to `client.sessionApi.clearUserSessions`
-- Model and Client methods change for `User` related operations
-- Model and Client methods change for `Rule` related operations
+See [MIGRATING.md](MIGRATING.md) for a full version-by-version migration guide.
 
 ## Building the SDK
 

--- a/scripts/clean-resources.sh
+++ b/scripts/clean-resources.sh
@@ -3,7 +3,7 @@
 source ${OKTA_HOME}/${REPO}/scripts/setup.sh
 
 export OKTA_CLIENT_ORGURL=https://node-sdk-oie.oktapreview.com
-export OKTA_CLIENT_CLIENTID=0oa1q34stxthm0zbJ1d7
+export OKTA_CLIENT_CLIENTID=0oaydmcaemQ3ht1c21d7
 get_terminus_secret "/" api_key OKTA_CLIENT_TOKEN
 get_terminus_secret "/" private_key OKTA_CLIENT_PRIVATEKEY
 get_terminus_secret "/" username ORG_USER

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -4,10 +4,10 @@ set -eo pipefail
 source ${OKTA_HOME}/${REPO}/scripts/setup.sh
 
 export OKTA_CLIENT_ORGURL=https://node-sdk-oie.oktapreview.com
-export OKTA_CLIENT_CLIENTID=0oa1q34stxthm0zbJ1d7
+export OKTA_CLIENT_CLIENTID=0oaydmcaemQ3ht1c21d7
 get_terminus_secret "/" api_key OKTA_CLIENT_TOKEN
 get_terminus_secret "/" private_key E2E_PK
-export OKTA_CLIENT_KEYID="vcwwhGUkVJbyKt3hu9DqKneDgjBD-IOQ-LLNNrtsCGg" # public key
+export OKTA_CLIENT_KEYID="PdKHqQFrIhifCvqgskm0ghu5dpPvLRPf_XVJLtB705g" # public key
 get_terminus_secret "/" username ORG_USER
 
 HEADER="-----BEGIN PRIVATE KEY-----"

--- a/test/it/authenticators-list.ts
+++ b/test/it/authenticators-list.ts
@@ -29,7 +29,7 @@ describe('Authenticators API tests', () => {
     const expectedTypes = new Set(['email', 'app', 'password', 'phone']);
     const foundTypes = new Set<string>();
     await authenticators.each(a => {
-      if (expectedTypes.has(a.type)) {
+      if (a.type && expectedTypes.has(a.type)) {
         foundTypes.add(a.type);
       }
     });

--- a/test/it/authenticators-list.ts
+++ b/test/it/authenticators-list.ts
@@ -26,14 +26,15 @@ describe('Authenticators API tests', () => {
 
   it('should list all available Authenticators', async () => {
     const authenticators = await client.authenticatorApi.listAuthenticators();
-    const expectedTypes = new Set(['email', 'app', 'password', 'phone']);
+    const expectedTypesList = ['email', 'app', 'password', 'phone'];
+    const expectedTypes = new Set(expectedTypesList);
     const foundTypes = new Set<string>();
     await authenticators.each(a => {
       if (a.type && expectedTypes.has(a.type)) {
         foundTypes.add(a.type);
       }
     });
-    for (const type of expectedTypes) {
+    for (const type of expectedTypesList) {
       expect(foundTypes.has(type), `Expected authenticator type '${type}' to be present`).to.be.true;
     }
   });

--- a/test/it/authenticators-list.ts
+++ b/test/it/authenticators-list.ts
@@ -26,11 +26,15 @@ describe('Authenticators API tests', () => {
 
   it('should list all available Authenticators', async () => {
     const authenticators = await client.authenticatorApi.listAuthenticators();
-    const expectedAuthenticators = ['email', 'app', 'password', 'phone'];
+    const expectedTypes = new Set(['email', 'app', 'password', 'phone']);
+    const foundTypes = new Set<string>();
     await authenticators.each(a => {
-      if (expectedAuthenticators.length) {
-        expect(a.type).to.equal(expectedAuthenticators.shift());
+      if (expectedTypes.has(a.type)) {
+        foundTypes.add(a.type);
       }
     });
+    for (const type of expectedTypes) {
+      expect(foundTypes.has(type), `Expected authenticator type '${type}' to be present`).to.be.true;
+    }
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-sdk-nodejs/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: N/A

- `CHANGELOG.md` had no entry for the upcoming 8.1.0 release.
- All migration guides (from 3.x through 8.x) were embedded inline in `README.md`, making the file very long and hard to maintain. There was no dedicated migration document.


## What is the new behavior?

**Modified files:**

- `CHANGELOG.md` — Added a new `8.1.0` section documenting all changes merged since 8.0.0:
  - **Fixes:** #472 (TypeScript discriminated union fix), #473 (ESM named imports), #474 (lodash security upgrade CVE-2025-13465), #487 (ProfileMapping properties serialization bug), #488 (HTTPS proxy agent preserved on retry), #489 (missing `items` field on `UserSchemaAttribute`)
  - **Dependencies:** #476 (mocha v10), #481 (flatted), #482 (picomatch), #484 (node-forge), #486 (lodash 4.18.1)
  - TypeScript-impacting fixes include `> Note` callouts for consumers.

- `README.md` — Replaced the ~230-line inline `## Migrating between versions` section with a single-line pointer to `MIGRATING.md`. Updated the version support table link accordingly. Updated the inline 7.x migration reference link.

**New file:**

- `MIGRATING.md` — Standalone migration guide covering all version transitions (8.0→8.1, 7.x→8.0, 6.x→7.0, 5.x→6.0, 4.x→5.0, 3.x→4.0), following the same pattern used in `okta-sdk-dotnet`.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

PRs included in the 8.1.0 changelog:
- https://github.com/okta/okta-sdk-nodejs/pull/472
- https://github.com/okta/okta-sdk-nodejs/pull/473
- https://github.com/okta/okta-sdk-nodejs/pull/474
- https://github.com/okta/okta-sdk-nodejs/pull/476
- https://github.com/okta/okta-sdk-nodejs/pull/481
- https://github.com/okta/okta-sdk-nodejs/pull/482
- https://github.com/okta/okta-sdk-nodejs/pull/484
- https://github.com/okta/okta-sdk-nodejs/pull/485 (internal only — not in changelog)
- https://github.com/okta/okta-sdk-nodejs/pull/486
- https://github.com/okta/okta-sdk-nodejs/pull/487
- https://github.com/okta/okta-sdk-nodejs/pull/488
- https://github.com/okta/okta-sdk-nodejs/pull/489

PRs #471 and #485 are internal test-only changes and are intentionally omitted from the changelog.

## Reviewers

