### PR TITLE
fix: preserve original query params across paginated Collection reque…

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -14,6 +14,36 @@
 const parseLinkHeader = require('parse-link-header');
 const { RequestContext, ResponseContext } = require('./generated/http/http');
 
+function splitUri(uri) {
+  const idx = uri.indexOf('?');
+  if (idx < 0) {
+    return { base: uri, query: '' };
+  }
+  return { base: uri.slice(0, idx), query: uri.slice(idx + 1) };
+}
+
+// Merge query params from the original request URI into the paginated `next`
+// URI, giving the `next` URI precedence. The Okta API does not always echo
+// request-shaping params (e.g. `expand`) in the Link header's `next` URL (#439),
+// which would otherwise drop them across pages.
+function mergePreservedQueryParams(originalQuery, nextUri) {
+  if (!originalQuery) {
+    return nextUri;
+  }
+  const { base, query: nextQuery } = splitUri(nextUri);
+  const originalParams = new URLSearchParams(originalQuery);
+  const nextParams = new URLSearchParams(nextQuery);
+  for (const key of new Set(originalParams.keys())) {
+    if (!nextParams.has(key)) {
+      for (const value of originalParams.getAll(key)) {
+        nextParams.append(key, value);
+      }
+    }
+  }
+  const merged = nextParams.toString();
+  return merged ? `${base}?${merged}` : base;
+}
+
 /**
  * Provides an interface to iterate over all objects in a collection that has pagination via Link headers
  */
@@ -28,6 +58,7 @@ class Collection {
    */
   constructor(httpApi, uri, factory, request) {
     this.nextUri = uri;
+    this.initialQuery = splitUri(uri).query;
     this.httpApi = httpApi;
     this.factory = factory;
     this.currentItems = [];
@@ -93,7 +124,7 @@ class Collection {
         if (link) {
           const parsed = parseLinkHeader(link);
           if (parsed.next) {
-            this.nextUri = parsed.next.url;
+            this.nextUri = mergePreservedQueryParams(this.initialQuery, parsed.next.url);
             return res instanceof ResponseContext ? this.factory.parseResponse(res) : res.json();
           }
         }

--- a/test/unit/collection.js
+++ b/test/unit/collection.js
@@ -82,6 +82,83 @@ describe('Collection', () => {
       const collection = new Collection(mockClient, '/', mockFactory, mockRequest);
       await collection.each(noop);
     });
+
+    it('should preserve original query params (e.g. expand) across paginated requests when the next Link header omits them', async () => {
+      // Regression test for #439: Okta's Link header does not echo `expand`
+      // in the next URL, so without preservation the second page drops it.
+      const requestedUris = [];
+      const mockClient = {
+        http: (uri) => {
+          requestedUris.push(uri);
+          return Promise.resolve({
+            headers: {
+              get: () => {
+                if (uri.startsWith('/api/v1/apps/app1/users?') && uri.includes('expand=user') && !uri.includes('after=')) {
+                  // First-page Link header — note: no expand param in next URL
+                  return '</api/v1/apps/app1/users?limit=5&after=cursor1>; rel="next"';
+                }
+              },
+            },
+            json: () => {
+              if (!uri.includes('after=')) {
+                return Promise.resolve([{ id: 'u1' }]);
+              }
+              if (uri.includes('after=cursor1')) {
+                return Promise.resolve([{ id: 'u2' }]);
+              }
+            }
+          });
+        }
+      };
+      const mockFactory = {
+        createInstance: (item) => item
+      };
+      const collection = new Collection(
+        mockClient,
+        '/api/v1/apps/app1/users?limit=5&expand=user',
+        mockFactory
+      );
+      const collected = [];
+      await collection.each((item) => {
+        collected.push(item);
+      });
+      expect(collected).to.deep.equal([{ id: 'u1' }, { id: 'u2' }]);
+      expect(requestedUris).to.have.lengthOf(2);
+      expect(requestedUris[0]).to.equal('/api/v1/apps/app1/users?limit=5&expand=user');
+      expect(requestedUris[1]).to.include('after=cursor1');
+      expect(requestedUris[1]).to.include('expand=user');
+    });
+
+    it('should let the next Link header override overlapping query params (e.g. after/cursor)', async () => {
+      const requestedUris = [];
+      const mockClient = {
+        http: (uri) => {
+          requestedUris.push(uri);
+          return Promise.resolve({
+            headers: {
+              get: () => {
+                if (!uri.includes('after=cursor2')) {
+                  return '</api/v1/users?limit=5&after=cursor2>; rel="next"';
+                }
+              },
+            },
+            json: () => {
+              return Promise.resolve([{}]);
+            }
+          });
+        }
+      };
+      const mockFactory = { createInstance: (item) => item };
+      const collection = new Collection(
+        mockClient,
+        '/api/v1/users?limit=5&after=cursor1&expand=user',
+        mockFactory
+      );
+      await collection.each(() => {});
+      expect(requestedUris[1]).to.include('after=cursor2');
+      expect(requestedUris[1]).to.not.include('after=cursor1');
+      expect(requestedUris[1]).to.include('expand=user');
+    });
   });
 
   describe('.subscribe()', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #439

When iterating a paginated `Collection` built from a request that carries
request-shaping query parameters (e.g. `expand=user` on
`listApplicationUsers`), the parameters are applied only to the first page.
The Okta API does not echo `expand` back in the `Link: rel="next"` URL, so
subsequent page requests are missing those params and return unexpanded
data.


## What is the new behavior?

`Collection` now captures the query parameters from the initial request URI
and merges any that are absent from the paginated `next` URL back in before
issuing the next request. Parameters present in the `next` URL (like
pagination cursors `after` / `before`) take precedence, so cursor-driven
pagination is unaffected. This restores `expand`, and any similarly-dropped
request-shaping params, across all pages.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

Added two regression tests in `test/unit/collection.js`:
- verifies `expand=user` from the initial URI is carried into the second
  page request when the server's `next` link omits it
- verifies the server's `next` link still wins for overlapping keys (e.g.
  the pagination cursor `after`)

## Reviewers
