### PR TITLE
fix(GroupProfile): restore custom group-profile attribute extensibility

### DIFF
--- a/scripts/fixSpec.cjs
+++ b/scripts/fixSpec.cjs
@@ -505,6 +505,7 @@ function fixExtensibleSchemas(spec) {
   // Schemas to add `x-okta-extensible`
   const schemasToForceExtensible = [
     'UserProfile',
+    'GroupProfile',
   ];
 
   for (const schemaKey in spec.components.schemas) {

--- a/src/generated/models/GroupProfile.js
+++ b/src/generated/models/GroupProfile.js
@@ -75,3 +75,4 @@ GroupProfile.attributeTypeMap = [
     'format': ''
   }
 ];
+GroupProfile.isExtensible = true;

--- a/src/types/generated/models/GroupProfile.d.ts
+++ b/src/types/generated/models/GroupProfile.d.ts
@@ -22,6 +22,7 @@
  * https://openapi-generator.tech
  * Do not edit the class manually.
  */
+import { CustomAttributeValue } from '../../custom-attributes';
 /**
 * Specifies required and optional properties for a group. The `objectClass` of a group determines which additional properties are available.  You can extend group profiles with custom properties, but you must first add the properties to the group profile schema before you can reference them. Use the Profile Editor in the Admin Console or the [Schemas API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Schema/) to manage schema extensions.  Custom properties can contain HTML tags. It is the client\'s responsibility to escape or encode this data before displaying it. Use [best-practices](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html) to prevent cross-site scripting.
 */
@@ -50,18 +51,20 @@ export declare class GroupProfile {
     * Fully qualified name of the Windows group
     */
   'windowsDomainQualifiedName'?: string;
-  static readonly discriminator: string | undefined;
-  static readonly attributeTypeMap: Array<{
+    [key: string]: CustomAttributeValue | CustomAttributeValue[] | undefined;
+    static readonly discriminator: string | undefined;
+    static readonly attributeTypeMap: Array<{
         name: string;
         baseName: string;
         type: string;
         format: string;
     }>;
-  static getAttributeTypeMap(): {
+    static readonly isExtensible = true;
+    static getAttributeTypeMap(): {
         name: string;
         baseName: string;
         type: string;
         format: string;
     }[];
-  constructor();
+    constructor();
 }

--- a/test/unit/group-profile-serialization.ts
+++ b/test/unit/group-profile-serialization.ts
@@ -1,0 +1,46 @@
+/*!
+ * Copyright (c) 2017-present, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { ObjectSerializer } from '../../src/generated/models/ObjectSerializer';
+
+// Regression test for: custom GroupProfile attributes stripped by the serializer.
+// Root cause: GroupProfile was not marked x-okta-extensible, so ObjectSerializer
+// discarded schema-extension attributes (those added via the Schemas API) on
+// both serialize and deserialize, matching the behavior of UserProfile and
+// OktaUserGroupProfile which remain extensible.
+
+describe('GroupProfile serialization', () => {
+  it('preserves custom (schema-extension) attributes during serialization', () => {
+    const input = {
+      name: 'West Coast Users',
+      description: 'All West Coast users',
+      customAttribute: 'custom-value',
+    };
+
+    const serialized = ObjectSerializer.serialize(input, 'GroupProfile', '');
+
+    expect(serialized).to.have.property('name', 'West Coast Users');
+    expect(serialized).to.have.property('customAttribute', 'custom-value');
+  });
+
+  it('preserves custom (schema-extension) attributes during deserialization', () => {
+    const raw = {
+      name: 'West Coast Users',
+      customAttribute: 'custom-value',
+    };
+
+    const deserialized = ObjectSerializer.deserialize(raw, 'GroupProfile', '');
+
+    expect(deserialized).to.have.property('customAttribute', 'custom-value');
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-sdk-nodejs/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`GroupProfile` is not marked `x-okta-extensible`, so `ObjectSerializer` strips
custom group-profile attributes — those added via the [Schemas API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Schema/) —
on both serialize and deserialize. Custom attributes therefore never reach Okta
on writes and are dropped on reads. This worked through 6.6.0 (#365) and
regressed afterwards. `UserProfile` and `OktaUserGroupProfile` remain extensible;
`GroupProfile` supports schema extensions the same way and should be too.

Issue Number: #238


## What is the new behavior?

`GroupProfile` is added to the force-extensible list in `scripts/fixSpec.cjs`
(alongside `UserProfile`) and the SDK regenerated. This restores, on
`GroupProfile`, the `CustomAttributeValue` import, the typed index signature, and
`static readonly isExtensible = true`, so custom attributes round-trip through
`ObjectSerializer` again.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

- Regenerated files (`src/generated/models/GroupProfile.js`,
  `src/types/generated/models/GroupProfile.d.ts`) are included, per CONTRIBUTING.
- Added `test/unit/group-profile-serialization.ts` covering the custom-attribute
  round-trip (serialize + deserialize).
- See also okta/okta-sdk-java#1642.
