### PR TITLE
fix: restore custom group-profile attribute extensibility on GroupProfile

### DIFF
--- a/scripts/fixSpec.cjs
+++ b/scripts/fixSpec.cjs
@@ -505,6 +505,11 @@ function fixExtensibleSchemas(spec) {
   // Schemas to add `x-okta-extensible`
   const schemasToForceExtensible = [
     'UserProfile',
+    // `GroupProfile` carries custom group attributes defined via the Schemas
+    // API. Mark it extensible so `ObjectSerializer` preserves those attributes
+    // on both serialize and deserialize, matching `OktaUserGroupProfile`. This
+    // was the behavior through 6.6.0 (#365) and regressed afterwards.
+    'GroupProfile',
   ];
 
   for (const schemaKey in spec.components.schemas) {

--- a/src/generated/models/GroupProfile.js
+++ b/src/generated/models/GroupProfile.js
@@ -75,3 +75,4 @@ GroupProfile.attributeTypeMap = [
     'format': ''
   }
 ];
+GroupProfile.isExtensible = true;

--- a/src/types/generated/models/GroupProfile.d.ts
+++ b/src/types/generated/models/GroupProfile.d.ts
@@ -22,6 +22,7 @@
  * https://openapi-generator.tech
  * Do not edit the class manually.
  */
+import { CustomAttributeValue } from '../../custom-attributes';
 /**
 * Specifies required and optional properties for a group. The `objectClass` of a group determines which additional properties are available.  You can extend group profiles with custom properties, but you must first add the properties to the group profile schema before you can reference them. Use the Profile Editor in the Admin Console or the [Schemas API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Schema/) to manage schema extensions.  Custom properties can contain HTML tags. It is the client\'s responsibility to escape or encode this data before displaying it. Use [best-practices](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html) to prevent cross-site scripting.
 */
@@ -50,18 +51,20 @@ export declare class GroupProfile {
     * Fully qualified name of the Windows group
     */
   'windowsDomainQualifiedName'?: string;
-  static readonly discriminator: string | undefined;
-  static readonly attributeTypeMap: Array<{
+    [key: string]: CustomAttributeValue | CustomAttributeValue[] | undefined;
+    static readonly discriminator: string | undefined;
+    static readonly attributeTypeMap: Array<{
         name: string;
         baseName: string;
         type: string;
         format: string;
     }>;
-  static getAttributeTypeMap(): {
+    static readonly isExtensible = true;
+    static getAttributeTypeMap(): {
         name: string;
         baseName: string;
         type: string;
         format: string;
     }[];
-  constructor();
+    constructor();
 }


### PR DESCRIPTION
## Summary

`GroupProfile` is not marked `x-okta-extensible`, so `ObjectSerializer` strips custom group-profile attributes (those added via the [Schemas API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Schema/)) on **both** serialize and deserialize. As a result, custom attributes never reach Okta on group create/update and are dropped when reading groups back.

This regressed after 6.6.0 (#365): `UserProfile` and `OktaUserGroupProfile` remain extensible, but `GroupProfile` does not, despite the API supporting custom group attributes.

## Fix

Add `GroupProfile` to the `schemasToForceExtensible` list in `scripts/fixSpec.cjs` (right next to `UserProfile`) and regenerate. This makes the model template emit the standard extensible output for `GroupProfile`:

- `static readonly isExtensible = true;`
- a typed index signature: `[key: string]: CustomAttributeValue | CustomAttributeValue[] | undefined;`
- the `CustomAttributeValue` import

…exactly matching `OktaUserGroupProfile`.

## Changes

- `scripts/fixSpec.cjs` — force `GroupProfile` extensible.
- `src/generated/models/GroupProfile.js`, `src/types/generated/models/GroupProfile.d.ts` — regenerated via `yarn build` (openapi-generator v7.13.0). Only `GroupProfile` is included; unrelated pre-existing regen drift was left out.

## Verification

Round-tripped a `GroupProfile` carrying a custom attribute through `ObjectSerializer`:

```js
const input = { name: 'Eng-Foo', orgChartId: 'team-foo' };
ObjectSerializer.serialize(input, 'GroupProfile', '').orgChartId;   // 'team-foo' (was dropped before)
ObjectSerializer.deserialize(serialized, 'GroupProfile', '').orgChartId; // 'team-foo'
```

Both preserve the custom attribute with this change; both dropped it before.

## Refs

- #238
- okta/okta-sdk-java#1642
