### PR TITLE
fix: expirePasswordAndGetTemporaryPassword deserializes response as U…

### DIFF
--- a/oas-spec/management.yaml
+++ b/oas-spec/management.yaml
@@ -24670,7 +24670,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/TempPassword'
               examples:
                 Expire password with temp password response:
                   $ref: '#/components/examples/ExpirePwdWithTempPwdResponse'

--- a/src/generated/apis/UserApi.js
+++ b/src/generated/apis/UserApi.js
@@ -2575,7 +2575,7 @@ class UserApiResponseProcessor {
   async expirePasswordAndGetTemporaryPassword(response) {
     const contentType = ObjectSerializer_1.ObjectSerializer.normalizeMediaType(response.headers['content-type']);
     if ((0, util_1.isCodeInRange)('200', response.httpStatusCode)) {
-      const body = ObjectSerializer_1.ObjectSerializer.deserialize(ObjectSerializer_1.ObjectSerializer.parse(await response.body.text(), contentType), 'User', '');
+      const body = ObjectSerializer_1.ObjectSerializer.deserialize(ObjectSerializer_1.ObjectSerializer.parse(await response.body.text(), contentType), 'TempPassword', '');
       return body;
     }
     if ((0, util_1.isCodeInRange)('403', response.httpStatusCode)) {
@@ -2592,7 +2592,7 @@ class UserApiResponseProcessor {
     }
     // Work around for missing responses in specification, e.g. for petstore.yaml
     if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
-      const body = ObjectSerializer_1.ObjectSerializer.deserialize(ObjectSerializer_1.ObjectSerializer.parse(await response.body.text(), contentType, 'User'), 'User', '');
+      const body = ObjectSerializer_1.ObjectSerializer.deserialize(ObjectSerializer_1.ObjectSerializer.parse(await response.body.text(), contentType, 'TempPassword'), 'TempPassword', '');
       return body;
     }
     throw new exception_1.ApiException(response.httpStatusCode, 'Unknown API Status Code!', await response.getBodyAsAny(), response.headers);

--- a/src/types/generated/apis/UserApi.d.ts
+++ b/src/types/generated/apis/UserApi.d.ts
@@ -29,6 +29,7 @@ import { ReplaceUserClassification } from '../models/ReplaceUserClassification';
 import { ResetPasswordToken } from '../models/ResetPasswordToken';
 import { ResponseLinks } from '../models/ResponseLinks';
 import { SocialAuthToken } from '../models/SocialAuthToken';
+import { TempPassword } from '../models/TempPassword';
 import { UpdateUserRequest } from '../models/UpdateUserRequest';
 import { User } from '../models/User';
 import { UserActivationToken } from '../models/UserActivationToken';
@@ -501,7 +502,7 @@ export declare class UserApiResponseProcessor {
      * @params response Response returned by the server for a request to expirePasswordAndGetTemporaryPassword
      * @throws ApiException if the response code was not in [200, 299]
      */
-  expirePasswordAndGetTemporaryPassword(response: ResponseContext): Promise<User>;
+  expirePasswordAndGetTemporaryPassword(response: ResponseContext): Promise<TempPassword>;
   /**
      * Unwraps the actual response sent by the server from the response context and deserializes the response content
      * to the expected objects

--- a/src/types/generated/types/ObjectParamAPI.d.ts
+++ b/src/types/generated/types/ObjectParamAPI.d.ts
@@ -330,6 +330,7 @@ import { SubmissionRequest } from '../models/SubmissionRequest';
 import { SubmissionResponse } from '../models/SubmissionResponse';
 import { Subscription } from '../models/Subscription';
 import { TacAuthenticatorEnrollment } from '../models/TacAuthenticatorEnrollment';
+import { TempPassword } from '../models/TempPassword';
 import { TenantSettings } from '../models/TenantSettings';
 import { TestInfo } from '../models/TestInfo';
 import { ThemeResponse } from '../models/ThemeResponse';
@@ -14958,7 +14959,7 @@ export declare class ObjectUserApi {
       * Expire the password with a temporary password
       * @param param the request object
       */
-  expirePasswordAndGetTemporaryPassword(param: UserApiExpirePasswordAndGetTemporaryPasswordRequest, options?: Configuration): Promise<User>;
+  expirePasswordAndGetTemporaryPassword(param: UserApiExpirePasswordAndGetTemporaryPasswordRequest, options?: Configuration): Promise<TempPassword>;
   /**
       * Starts the forgot password flow.  Generates a one-time token (OTT) that you can use to reset a user\'s password.  The user must validate their security question\'s answer when visiting the reset link. Perform this operation only on users with an `ACTIVE` status and a valid [recovery question credential](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/User/#tag/User/operation/createUser!path=credentials/recovery_question&t=request).  > **Note:** If you have migrated to Identity Engine, you can allow users to recover passwords with any enrolled MFA authenticator. See [Self-service account recovery](https://help.okta.com/oie/en-us/content/topics/identity-engine/authenticators/configure-sspr.htm?cshid=ext-config-sspr).  If an email address is associated with multiple users, keep in mind the following to ensure a successful password recovery lookup:   * Okta no longer includes deactivated users in the lookup.   * The lookup searches sign-in IDs first, then primary email addresses, and then secondary email addresses.  If `sendEmail` is `false`, returns a link for the user to reset their password. This operation doesn\'t affect the status of the user.
       * Start forgot password flow

--- a/src/types/generated/types/ObservableAPI.d.ts
+++ b/src/types/generated/types/ObservableAPI.d.ts
@@ -331,6 +331,7 @@ import { SubmissionRequest } from '../models/SubmissionRequest';
 import { SubmissionResponse } from '../models/SubmissionResponse';
 import { Subscription } from '../models/Subscription';
 import { TacAuthenticatorEnrollment } from '../models/TacAuthenticatorEnrollment';
+import { TempPassword } from '../models/TempPassword';
 import { TenantSettings } from '../models/TenantSettings';
 import { TestInfo } from '../models/TestInfo';
 import { ThemeResponse } from '../models/ThemeResponse';
@@ -5830,7 +5831,7 @@ export declare class ObservableUserApi {
       * @param userId An ID, login, or login shortname (as long as the shortname is unambiguous) of an existing Okta user
       * @param revokeSessions Revokes the user\&#39;s existing sessions if &#x60;true&#x60;
       */
-  expirePasswordAndGetTemporaryPassword(userId: string, revokeSessions?: boolean, _options?: Configuration): Observable<User>;
+  expirePasswordAndGetTemporaryPassword(userId: string, revokeSessions?: boolean, _options?: Configuration): Observable<TempPassword>;
   /**
       * Starts the forgot password flow.  Generates a one-time token (OTT) that you can use to reset a user\'s password.  The user must validate their security question\'s answer when visiting the reset link. Perform this operation only on users with an `ACTIVE` status and a valid [recovery question credential](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/User/#tag/User/operation/createUser!path=credentials/recovery_question&t=request).  > **Note:** If you have migrated to Identity Engine, you can allow users to recover passwords with any enrolled MFA authenticator. See [Self-service account recovery](https://help.okta.com/oie/en-us/content/topics/identity-engine/authenticators/configure-sspr.htm?cshid=ext-config-sspr).  If an email address is associated with multiple users, keep in mind the following to ensure a successful password recovery lookup:   * Okta no longer includes deactivated users in the lookup.   * The lookup searches sign-in IDs first, then primary email addresses, and then secondary email addresses.  If `sendEmail` is `false`, returns a link for the user to reset their password. This operation doesn\'t affect the status of the user.
       * Start forgot password flow

--- a/src/types/generated/types/PromiseAPI.d.ts
+++ b/src/types/generated/types/PromiseAPI.d.ts
@@ -330,6 +330,7 @@ import { SubmissionRequest } from '../models/SubmissionRequest';
 import { SubmissionResponse } from '../models/SubmissionResponse';
 import { Subscription } from '../models/Subscription';
 import { TacAuthenticatorEnrollment } from '../models/TacAuthenticatorEnrollment';
+import { TempPassword } from '../models/TempPassword';
 import { TenantSettings } from '../models/TenantSettings';
 import { TestInfo } from '../models/TestInfo';
 import { ThemeResponse } from '../models/ThemeResponse';
@@ -5677,7 +5678,7 @@ export declare class PromiseUserApi {
       * @param userId An ID, login, or login shortname (as long as the shortname is unambiguous) of an existing Okta user
       * @param revokeSessions Revokes the user\&#39;s existing sessions if &#x60;true&#x60;
       */
-  expirePasswordAndGetTemporaryPassword(userId: string, revokeSessions?: boolean, _options?: Configuration): Promise<User>;
+  expirePasswordAndGetTemporaryPassword(userId: string, revokeSessions?: boolean, _options?: Configuration): Promise<TempPassword>;
   /**
       * Starts the forgot password flow.  Generates a one-time token (OTT) that you can use to reset a user\'s password.  The user must validate their security question\'s answer when visiting the reset link. Perform this operation only on users with an `ACTIVE` status and a valid [recovery question credential](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/User/#tag/User/operation/createUser!path=credentials/recovery_question&t=request).  > **Note:** If you have migrated to Identity Engine, you can allow users to recover passwords with any enrolled MFA authenticator. See [Self-service account recovery](https://help.okta.com/oie/en-us/content/topics/identity-engine/authenticators/configure-sspr.htm?cshid=ext-config-sspr).  If an email address is associated with multiple users, keep in mind the following to ensure a successful password recovery lookup:   * Okta no longer includes deactivated users in the lookup.   * The lookup searches sign-in IDs first, then primary email addresses, and then secondary email addresses.  If `sendEmail` is `false`, returns a link for the user to reset their password. This operation doesn\'t affect the status of the user.
       * Start forgot password flow

--- a/test/unit/user-response-processor-edge-cases.ts
+++ b/test/unit/user-response-processor-edge-cases.ts
@@ -209,6 +209,7 @@ describe('UserApiResponseProcessor - Edge Cases', () => {
       const response = createMockResponse(201, mockBody);
       const result = await processor.expirePasswordAndGetTemporaryPassword(response as any);
       expect(result).to.be.an('object');
+      expect((result as any).tempPassword).to.equal('temp123');
     });
 
     it('should throw on 500 error', async () => {

--- a/test/unit/user-response-processor.ts
+++ b/test/unit/user-response-processor.ts
@@ -464,6 +464,7 @@ describe('UserApiResponseProcessor', () => {
       const response = createMockResponse(200, mockBody);
       const result = await processor.expirePasswordAndGetTemporaryPassword(response as any);
       expect(result).to.be.an('object');
+      expect((result as any).tempPassword).to.equal('temp123');
     });
 
     it('should throw ApiException on 403', async () => {


### PR DESCRIPTION
…ser instead of TempPassword

The expire_password_with_temp_password endpoint returns {"tempPassword": "..."}, but the generated response processor deserialized it against the User model, silently dropping the tempPassword property and returning it empty.

Fix the response schema/deserialization to use TempPassword, matching the pre-v7.1.1 behavior, and strengthen the existing unit tests to assert the temp password value is actually preserved.

OKTA-1206504

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our [guidelines](/okta/okta-sdk-nodejs/blob/master/CONTRIBUTING.md)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

